### PR TITLE
fix: stop the home menu dropping Settings when BookOrbit is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ on; for everything inherited from upstream, see the
 
 - BookOrbit authentication now releases the settings screens it was opened from before connecting. Those screens hold 15-20 KB, and on this hardware a TLS handshake completes with only a few KB to spare, so authentication could fail outright while the same server answered fine from the catalog — which already worked this way. Nothing changes on screen: authenticating brought WiFi up, and that has always ended in a silent restart to the home screen.
 - The clock's NTP refresh no longer leaves the SNTP client running once it has read the time. On devices without a clock chip that refresh happens on every WiFi connection, immediately before whatever request you connected for, and the idle client held a socket and its buffers for the rest of the session — memory the following HTTPS connection needs on hardware this tight.
+- Settings is reachable again from the home menu. The home menu held at most eight entries and silently dropped anything beyond that; adding BookOrbit made nine on devices that also have OPDS servers, reading stats and bookmarks, and Settings — pushed last — was the one dropped. It was missing from the list entirely, which is why scrolling never reached it.
 - The reader's top clock and the first line of book text no longer touch: the text now keeps a few pixels of clearance below the clock band.
 
 ## [v1.4.1+bookorbit.1] - 2026-07-31

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -69,12 +69,21 @@ struct HomeMenuEntry {
 };
 
 struct HomeMenuEntries {
-  static constexpr int kCapacity = 8;
+  // Room for every entry the fullest menu can hold, with headroom. That menu is the
+  // selectable one: Continue Reading, Browse Files, Recent Books, OPDS, BookOrbit, Reading
+  // Stats, Bookmarks/Clippings, File Transfer and Settings — nine. It was exactly eight
+  // before BookOrbit was added, so the ninth was dropped, and since Settings is pushed last
+  // it was Settings that vanished from the home menu. Overflow is logged rather than silent
+  // so the next entry added here cannot repeat that.
+  static constexpr int kCapacity = 12;
   std::array<HomeMenuEntry, kCapacity> entries{};
   int count = 0;
 
   void push(const HomeMenuEntry& entry) {
-    if (count >= kCapacity) return;
+    if (count >= kCapacity) {
+      LOG_ERR("HOME", "Home menu is full (%d); dropping entry '%s'", kCapacity, entry.label ? entry.label : "");
+      return;
+    }
     entries[count++] = entry;
   }
 


### PR DESCRIPTION
## Summary

Raise the limit past what the menu can hold and log an overflow instead of dropping in silence.

