### PR TITLE
feat: push reading statistics to BookOrbit

### DIFF
--- a/.claude/CONTEXT.md
+++ b/.claude/CONTEXT.md
@@ -31,6 +31,8 @@ Keep this file focused on repo-specific gotchas that are worth reusing in future
 
 ## Misc Repo Gotchas
 
+- On the X4, `RTC_NOINIT_ATTR` data does NOT survive deep sleep (every wake read as garbage), while the system clock itself DOES survive both deep sleep and software resets (RTS/EN flash resets included). Never key state to RTC memory across sleeps; persist to SD and use clock plausibility for cold-boot detection (see lib/WallClock).
+- `WallClock` eras are what make retroactive timestamp correction sound: a clock loss always increments the era BEFORE the checkpoint is restored, so within one era the clock can only have drifted, never stepped. That is why a same-era correction may be interpolated between two syncs, while an era that opened on a clock loss takes its measured error as a flat shift — its error starts at the unknown powered-off duration, not at zero. Do not blend the two.
 
 - POSIX TZ signs are inverted from ISO 8601 in `TimeStore::applyTimezone()`: `"UTC-1"` means UTC+1.
 - `LyraTheme::drawHeader()` does not call `BaseTheme::drawHeader()`, so header changes in the base theme must be duplicated in Lyra if needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ on; for everything inherited from upstream, see the
 ### Added
 
 - The clock in the top status bar now works on devices without a clock chip (the X4), reading the system clock. The clock is refreshed from NTP on every WiFi connection on those devices. Hide Clock, Clock Format and Clock UTC Offset are all reachable now — they were hidden without a real RTC, which made the clock impossible to enable or configure.
+- Reading activity is now uploaded to BookOrbit's reading-statistics dashboard on each BookOrbit sync, as per-page reading events like BookOrbit's own KOReader plugin sends — feeding its reading time, streaks, pace and reading-DNA stats with full granularity (BookOrbit's API is upload-only, so stats flow from CrossInk to BookOrbit).
+- Reading-session timestamps are corrected retroactively at sync time, using the clock error each sync measures. When the clock ran continuously since the previous sync, the error is drift and is spread across the sessions in proportion to when they happened; when the clock had been lost and restored, the whole block of sessions is shifted instead, keeping the gaps between them intact. Either way, sessions land at the right moment in BookOrbit's dashboard instead of at the moment they were uploaded.
 - "Keep Clock While Asleep" (Settings > System > Device, only shown on devices without a clock chip): keeps the board powered during sleep so wall-clock time keeps running instead of being lost at every sleep. Off by default, because it trades standby battery life for that: with it enabled the device no longer powers off completely when it sleeps and keeps drawing a small current, so it slowly discharges even when unused. Watch your own battery for a few days before relying on it. Turning the setting off restores the previous behaviour exactly.
 
 ### Fixed
@@ -18,6 +20,8 @@ on; for everything inherited from upstream, see the
 - The clock's NTP refresh no longer leaves the SNTP client running once it has read the time. On devices without a clock chip that refresh happens on every WiFi connection, immediately before whatever request you connected for, and the idle client held a socket and its buffers for the rest of the session — memory the following HTTPS connection needs on hardware this tight.
 - Settings is reachable again from the home menu. The home menu held at most eight entries and silently dropped anything beyond that; adding BookOrbit made nine on devices that also have OPDS servers, reading stats and bookmarks, and Settings — pushed last — was the one dropped. It was missing from the list entirely, which is why scrolling never reached it.
 - The reader's top clock and the first line of book text no longer touch: the text now keeps a few pixels of clearance below the clock band.
+- The BookOrbit stats upload no longer builds its `pluginVersion` from the firmware version string: the server caps that field at 20 characters and rejected the whole upload from `xlarge` and dev builds (finding adopted from the samfoy/CrossInk fork, verified against a live server).
+- BookOrbit servers that predate the page-stats endpoint no longer cause queued stats to retry forever: the queue self-heals (drops with a log) on HTTP 404/405/501.
 
 ## [v1.4.1+bookorbit.1] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Everything else — fonts, themes, reader features, reading stats, controls, the
 - **BookOrbit progress sync** — sync your reading position with a self-hosted BookOrbit server, independently of (and alongside) KOReader Sync.
 - **BookOrbit catalog browser** — browse your server's library on the device and download EPUBs over WiFi, including by author and by series.
 - **Offline shortcuts to your own books** — "On device" and "In progress" categories that open a book directly, without touching the network.
+- **Reading statistics pushed to BookOrbit** — your reading time, streaks and pace on the server's dashboard, fed by the pages you turn on the device.
 - **A working clock on the X4** — the status-bar clock, which upstream can only show on hardware that has a clock chip, plus an opt-in mode that keeps the time running through sleep.
 
 BookOrbit exposes a KOReader-compatible sync API, so this fork talks to it the same way the official BookOrbit KOReader plugin does. Your BookOrbit server must be recent enough to serve the KOReader plugin endpoints under `{server}/api/v1/koreader` — including `plugin/catalog/*` for the catalog browser.
@@ -39,6 +40,60 @@ BookOrbit identifies books by the binary partial-MD5 hash of the EPUB file (the 
 ### Syncing without opening the menu
 
 **Settings → Controls** lets you bind _BookOrbit Sync_ to the power button (short or long press) or to a long press on Menu or Back. The action also works outside the reader: it syncs the book you last had open, or opens the BookOrbit settings if no account is configured yet.
+
+## Reading statistics
+
+Every BookOrbit sync of a book also uploads the reading it has recorded since the last
+one: one event per page you read, with when you started it and how long you stayed on it.
+That is what the official BookOrbit KOReader plugin sends too, so the server's reading
+time, streaks, pace and reading-DNA views fill in the same way. It is one-way — BookOrbit
+has no API to read stats back — so the device's own Reading Stats screens are unaffected
+and keep working offline.
+
+Nothing to enable: if an account is configured, the events ride along with each sync. They
+are queued per book on the SD card in the meantime, so nothing is lost if you read offline
+for a week.
+
+### How faithful the timestamps are
+
+**On the X3 this section does not apply**: it has a clock chip, so every page event is
+stamped with the real time and lands exactly where it belongs.
+
+The X4 has no clock chip. Its clock stops whenever the device sleeps, and the firmware can
+only put it back to the last time it knew about at wake — so a page read at 20:00 can be
+recorded as if it happened at 08:20. Rather than upload that, the device records which
+_clock timeline_ each event belongs to and fixes the timestamps at upload time, using the
+error each sync measures against NTP. Two cases:
+
+- **With Settings → System → Device → Keep Clock While Asleep on**, the clock never stops,
+  so the only error is the oscillator's drift — a couple of minutes per 12 h. Each sync
+  measures that drift and spreads it across the events in proportion to when they
+  happened, so sessions land within seconds of reality. Nothing to think about. Note that
+  the drift is only corrected in the _uploaded stats_: the clock **shown** on screen stays
+  a minute or two off until the next WiFi connection resets it.
+- **With the option off**, accuracy depends on you syncing at least once per run — a run
+  being everything between two sleeps. A sync anchors the run's whole timeline, so every
+  session it uploads is placed correctly, including the ones read before it in that run.
+
+The friction points of leaving the option off:
+
+- **A run with no sync in it keeps a wrong timestamp for good.** Its sessions are dated
+  from the last time the device knew, which is where the _previous_ run ended — so they
+  pile up right after it. Read in the morning, sleep, read in the evening and sync only
+  then, and the morning session is the one that lands wrong, possibly on the previous day.
+  That is a real cost on the server side: BookOrbit's streaks and daily charts key off the
+  date, so a misdated session breaks a streak that you did not actually break.
+- **The order and the pacing are always right, only the anchor moves.** Gaps between pages
+  within a run are measured by a timer that keeps running, so a shifted block stays
+  internally exact — a session never appears to last longer or shorter than it did.
+- **It gets worse with each sleep, not with time.** Three runs without a sync means three
+  blocks stacked onto the same anchor, not a gradual smear.
+- **The cheap mitigation is a button.** Bind _BookOrbit Sync_ to the power button under
+  **Settings → Controls** and press it when you put the book down; one sync per run is all
+  the accuracy needs. It is also what drains the queue, so it costs nothing extra.
+- **A flat battery or a firmware flash loses the clock entirely.** The sessions queued
+  before that still upload correctly as long as a sync happens in the same run, because
+  they are placed relative to that sync rather than by absolute time.
 
 ## Browsing and downloading from the catalog
 
@@ -86,13 +141,17 @@ Before leaving it on, know that:
 
 - **the device no longer powers off completely when it sleeps.** It keeps drawing a small
   current, so it will slowly discharge in a drawer instead of sitting indefinitely.
-- **the cost has only been spot-checked.** On an X4, an hour of sleep with the setting
-  enabled cost under 1% of battery with no visible clock drift. The fuel gauge only
-  reports whole percent, so a single hour bounds the drain loosely — somewhere between
-  roughly four days and a month of standby. Treat it as "not catastrophic" rather than as
-  a measured figure, and watch your own battery over a few days before relying on it.
+- **the cost has only been spot-checked.** On an X4, twelve hours of sleep with the setting
+  enabled cost about 5% of battery, which extrapolates to roughly ten days of standby.
+  Over the same twelve hours the clock drifted two to three minutes, since it runs on an
+  internal RC oscillator rather than a crystal; the next WiFi connection resets it. Treat
+  both as one measurement rather than a specification, and watch your own battery over a
+  few days before relying on it.
 
 Turning the setting back off restores the stock behaviour exactly.
+
+It also decides how faithful your uploaded reading-session timestamps are — see
+[Reading statistics](#reading-statistics), which is the main reason to leave it on.
 
 ---
 

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -227,6 +227,80 @@ Binary layout:
 - `[41-68]` `dayOfWeekSeconds[7]` (`uint32_t` LE each)
 - `[69-72]` `estimatedTimeLeftSeconds` (`uint32_t` LE, `0` means unavailable)
 
+## `bookorbit_stats.bin`
+
+### Version 1
+
+`bookorbit_stats.bin` is a queue of per-page reading events in a book's cache
+directory, waiting to be uploaded to a BookOrbit server's page-stats endpoint
+(the server clusters raw page events into the reading sessions that power its
+time/streak/pace stats). The reader buffers one record per qualifying forward
+page read in RAM and appends them as a single batch when the session ends;
+BookOrbitSyncActivity uploads and deletes the file on the next successful
+BookOrbit sync of that book. The queue is capped at 2000 records; on overflow
+the oldest records are dropped.
+
+Each record carries the WallClock power era its timestamp was taken in, plus a
+flag marking the timestamp approximate (taken from the system clock rather than a
+battery-backed RTC), so it can be corrected to real time at upload — see
+`wallclock.bin`. A queue whose header does not match is discarded on read and
+replaced on append.
+
+Binary layout (all little-endian):
+
+- `[0-3]` magic + version: ASCII `BOQ1`
+- Repeated 16-byte records:
+  - `[0-3]` `startTime` (`uint32_t`, page-read start as UTC epoch seconds, possibly approximate)
+  - `[4-7]` `durationSeconds` (`uint32_t`, dwell seconds on the page)
+  - `[8-9]` `page` (`uint16_t`, overall book position in basis points 0-10000)
+  - `[10-11]` `totalPages` (`uint16_t`, the position denominator, `10000`)
+  - `[12-13]` `era` (`uint16_t`, truncated WallClock power era the timestamp was taken in)
+  - `[14]` `flags` (`uint8_t`, bit0 = clock was approximate / not NTP-confirmed)
+  - `[15]` reserved
+
+## `/.crosspoint/wallclock.bin`
+
+### Version 1
+
+WallClock's persisted state for devices without a battery-backed RTC: the
+clock-timeline counter ("era"), the last known-good time checkpoint used to
+restore an approximate system clock after the clock is lost, and a ring of
+NTP-measured corrections that let queued timestamps (see
+`bookorbit_stats.bin`) be resolved to real time retroactively.
+
+Eras are keyed to clock continuity — a boot with a plausible system time
+continues the previous era — because RTC memory does not reliably survive deep
+sleep on this hardware. A clock loss therefore always opens a new era, which is
+what lets a correction tell drift apart from powered-off time.
+
+Each correction carries its sync anchor pair, which makes it a drift ramp rather
+than a flat offset: `delta` is the error measured at `syncDeviceEpoch`, and
+`windowStartEpoch` is the real time of the previous sync in the same era — an
+instant where the error was zero by construction, since that sync set the clock.
+Timestamps between the two are interpolated. `windowStartEpoch` is 0 when the era
+opened on a clock loss, because the error then starts at the unknown powered-off
+duration and `delta` applies as a flat shift instead.
+
+Only eras where NTP actually ran appear in the ring; it replaces its lowest-era
+entry when full, so timestamps survive several clock losses between syncs.
+
+Binary layout (all little-endian):
+
+- `[0-3]` magic + version: ASCII `WCK1`
+- `[4-7]` `era` (`uint32_t`, incremented once per clock-loss boot)
+- `[8-11]` `checkpointEpoch` (`uint32_t`, UTC epoch of the last trusted checkpoint)
+
+Then `ERA_HISTORY` (6) correction records of 24 bytes each:
+
+- `[0-3]` `era` (`uint32_t`)
+- `[4]` `used` (`uint8_t`, 1 when the slot holds a valid record)
+- `[5-7]` reserved
+- `[8-15]` `delta` (`int64_t`, seconds of clock error at `syncDeviceEpoch`)
+- `[16-19]` `windowStartEpoch` (`uint32_t`, real time of the previous same-era
+  sync, or 0 for a flat correction)
+- `[20-23]` `syncDeviceEpoch` (`uint32_t`, the clock reading just before the
+  sync that measured `delta`)
+
 ## `section.bin`
 
 ### Version 44

--- a/lib/BookOrbitSync/BookOrbitStatsQueue.cpp
+++ b/lib/BookOrbitSync/BookOrbitStatsQueue.cpp
@@ -1,0 +1,199 @@
+#include "BookOrbitStatsQueue.h"
+
+#include <HalClock.h>
+#include <HalStorage.h>
+#include <Logging.h>
+#include <WallClock.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace {
+constexpr char QUEUE_FILENAME[] = "/bookorbit_stats.bin";
+// 4-byte header: magic + format version. Bump the version if the record layout changes
+// and document it in docs/file-formats.md; queues whose header does not match are
+// discarded on read and replaced on append, so a bump costs at most the events that
+// were still waiting to be uploaded.
+constexpr char QUEUE_MAGIC[4] = {'B', 'O', 'Q', '1'};
+
+std::string queuePath(const std::string& bookCachePath) { return bookCachePath + QUEUE_FILENAME; }
+
+// Howard Hinnant's days_from_civil: days since 1970-01-01 for a Gregorian date.
+int32_t daysFromCivil(int year, unsigned month, unsigned day) {
+  year -= month <= 2;
+  const int32_t era = (year >= 0 ? year : year - 399) / 400;
+  const uint32_t yoe = static_cast<uint32_t>(year - era * 400);
+  const uint32_t doy = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1;
+  const uint32_t doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+  return era * 146097 + static_cast<int32_t>(doe) - 719468;
+}
+
+// The DS3231 is synced in UTC (see HalClock); only present on the X3.
+bool rtcUtcEpoch(uint32_t& outEpochSeconds) {
+  uint16_t year = 0;
+  uint8_t month = 0;
+  uint8_t day = 0;
+  uint8_t hour = 0;
+  uint8_t minute = 0;
+  if (!halClock.getDateTime(year, month, day, hour, minute)) {
+    return false;
+  }
+  if (year < 2020 || year > 2100 || month < 1 || month > 12 || day < 1 || day > 31) {
+    return false;
+  }
+  const int32_t days = daysFromCivil(year, month, day);
+  outEpochSeconds = static_cast<uint32_t>(days) * 86400u + hour * 3600u + minute * 60u;
+  return true;
+}
+}  // namespace
+
+namespace {
+// Writes header + records to a freshly truncated queue file.
+bool rewriteQueue(const char* path, const std::vector<BookOrbitStatEvent>& events, size_t firstIndex) {
+  FsFile file;
+  if (!Storage.openFileForWrite("BOQ", path, file)) {
+    LOG_ERR("BOQ", "Failed to open stats queue for rewrite: %s", path);
+    return false;
+  }
+  bool ok = file.write(QUEUE_MAGIC, sizeof(QUEUE_MAGIC)) == sizeof(QUEUE_MAGIC);
+  for (size_t i = firstIndex; ok && i < events.size(); i++) {
+    ok = file.write(&events[i], sizeof(BookOrbitStatEvent)) == sizeof(BookOrbitStatEvent);
+  }
+  file.close();
+  if (!ok) {
+    LOG_ERR("BOQ", "Failed to rewrite stats queue");
+  }
+  return ok;
+}
+}  // namespace
+
+bool BookOrbitStatsQueue::appendBatch(const std::string& bookCachePath, const std::vector<BookOrbitStatEvent>& events) {
+  if (events.empty()) {
+    return true;
+  }
+  const std::string path = queuePath(bookCachePath);
+
+  // Never append onto a queue with an old/foreign header: readAll() would discard
+  // the whole file — including the records we are about to add. Recreate it instead.
+  size_t existingCount = 0;
+  if (Storage.exists(path.c_str())) {
+    FsFile existing;
+    char magic[4] = {};
+    const bool headerOk = Storage.openFileForRead("BOQ", path.c_str(), existing) &&
+                          existing.read(magic, sizeof(magic)) == sizeof(magic) &&
+                          memcmp(magic, QUEUE_MAGIC, sizeof(QUEUE_MAGIC)) == 0;
+    if (headerOk) {
+      existingCount = (existing.fileSize() - sizeof(QUEUE_MAGIC)) / sizeof(BookOrbitStatEvent);
+    }
+    if (existing.isOpen()) existing.close();
+    if (!headerOk) {
+      LOG_INF("BOQ", "Replacing old-format stats queue: %s", path.c_str());
+      Storage.remove(path.c_str());
+    }
+  }
+
+  // Cap overflow: drop the OLDEST events (recent reading beats stale backlog).
+  if (existingCount + events.size() > MAX_QUEUED_EVENTS) {
+    std::vector<BookOrbitStatEvent> merged;
+    if (!readAll(bookCachePath, merged)) {
+      merged.clear();
+    }
+    merged.reserve(merged.size() + events.size());
+    merged.insert(merged.end(), events.begin(), events.end());
+    const size_t firstKept = merged.size() > MAX_QUEUED_EVENTS ? merged.size() - MAX_QUEUED_EVENTS : 0;
+    LOG_INF("BOQ", "Stats queue over cap; dropping %u oldest events", (unsigned)firstKept);
+    return rewriteQueue(path.c_str(), merged, firstKept);
+  }
+
+  FsFile file = Storage.open(path.c_str(), O_WRONLY | O_CREAT | O_APPEND);
+  if (!file) {
+    LOG_ERR("BOQ", "Failed to open stats queue for append: %s", path.c_str());
+    return false;
+  }
+
+  bool ok = true;
+  if (file.fileSize() == 0) {
+    ok = file.write(QUEUE_MAGIC, sizeof(QUEUE_MAGIC)) == sizeof(QUEUE_MAGIC);
+  }
+  for (size_t i = 0; ok && i < events.size(); i++) {
+    ok = file.write(&events[i], sizeof(BookOrbitStatEvent)) == sizeof(BookOrbitStatEvent);
+  }
+  const size_t totalBytes = file.fileSize();
+  file.close();
+  if (!ok) {
+    LOG_ERR("BOQ", "Failed to append stats queue batch");
+  } else {
+    // INF so field logs show whether a session's events reached the SD queue (and
+    // how many the file holds) — key evidence when sessions go missing at sync.
+    LOG_INF("BOQ", "Queued %u events (file now holds %u)", (unsigned)events.size(),
+            (unsigned)((totalBytes - sizeof(QUEUE_MAGIC)) / sizeof(BookOrbitStatEvent)));
+  }
+  return ok;
+}
+
+bool BookOrbitStatsQueue::readAll(const std::string& bookCachePath, std::vector<BookOrbitStatEvent>& outEvents) {
+  outEvents.clear();
+  const std::string path = queuePath(bookCachePath);
+  if (!Storage.exists(path.c_str())) {
+    return true;
+  }
+
+  FsFile file;
+  if (!Storage.openFileForRead("BOQ", path.c_str(), file)) {
+    return false;
+  }
+
+  char magic[4];
+  if (file.read(magic, sizeof(magic)) != sizeof(magic) || memcmp(magic, QUEUE_MAGIC, sizeof(QUEUE_MAGIC)) != 0) {
+    LOG_ERR("BOQ", "Old or bad stats queue header, discarding queue: %s", path.c_str());
+    file.close();
+    Storage.remove(path.c_str());
+    return true;
+  }
+
+  const size_t recordBytes = file.fileSize() - sizeof(QUEUE_MAGIC);
+  outEvents.reserve(std::min(recordBytes / sizeof(BookOrbitStatEvent), MAX_QUEUED_EVENTS));
+
+  BookOrbitStatEvent event;
+  while (outEvents.size() < MAX_QUEUED_EVENTS && file.read(&event, sizeof(event)) == sizeof(event)) {
+    outEvents.push_back(event);
+  }
+  file.close();
+  return true;
+}
+
+size_t BookOrbitStatsQueue::queuedCount(const std::string& bookCachePath) {
+  const std::string path = queuePath(bookCachePath);
+  if (!Storage.exists(path.c_str())) return 0;
+  FsFile file;
+  if (!Storage.openFileForRead("BOQ", path.c_str(), file)) return 0;
+  char magic[4];
+  size_t count = 0;
+  if (file.read(magic, sizeof(magic)) == sizeof(magic) && memcmp(magic, QUEUE_MAGIC, sizeof(QUEUE_MAGIC)) == 0) {
+    count = (file.fileSize() - sizeof(QUEUE_MAGIC)) / sizeof(BookOrbitStatEvent);
+  }
+  file.close();
+  return count;
+}
+
+void BookOrbitStatsQueue::clear(const std::string& bookCachePath) {
+  const std::string path = queuePath(bookCachePath);
+  if (Storage.exists(path.c_str())) {
+    Storage.remove(path.c_str());
+  }
+}
+
+bool BookOrbitStatsQueue::captureNow(uint32_t& outEpochSeconds, bool& outApproximate) {
+  if (rtcUtcEpoch(outEpochSeconds)) {
+    outApproximate = false;  // battery-backed DS3231: genuinely absolute time
+    return true;
+  }
+
+  const bool plausible = WallClock::now(outEpochSeconds);
+  // The system clock runs on the internal RC oscillator and drifts by minutes across
+  // long deep sleeps, so even an NTP-confirmed clock goes stale. Every system-clock
+  // stamp is therefore marked correctable and re-resolved against fresh NTP at
+  // upload time (see BookOrbitSyncActivity::uploadQueuedStats).
+  outApproximate = true;
+  return plausible || outEpochSeconds != 0;
+}

--- a/lib/BookOrbitSync/BookOrbitStatsQueue.h
+++ b/lib/BookOrbitSync/BookOrbitStatsQueue.h
@@ -1,0 +1,74 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/**
+ * One per-page reading event queued for upload to BookOrbit's page-stats endpoint,
+ * matching what BookOrbit's own KOReader plugin sends (the server clusters raw page
+ * events into reading sessions, which power its time/streak/pace/reading-DNA stats).
+ *
+ * CrossPoint page numbers are per-chapter and layout-dependent, so events store the
+ * overall book position in basis points instead: page N of totalPages=10000, so
+ * page/totalPages reproduces the exact reading fraction on any device.
+ *
+ * `era`/`flags` exist because the X4 has no battery-backed RTC: events recorded
+ * before the clock was NTP-confirmed carry CLOCK_APPROXIMATE and the WallClock power
+ * era they were stamped in. Same-era events are corrected to exact time at upload
+ * (see BookOrbitSyncActivity::uploadQueuedStats); older-era events upload with their
+ * checkpoint-approximate stamps.
+ */
+struct BookOrbitStatEvent {
+  uint32_t startTime = 0;        // Page-read start, UTC epoch seconds (possibly approximate)
+  uint32_t durationSeconds = 0;  // Dwell time on the page in seconds
+  uint16_t page = 0;             // Overall book position in basis points (0-10000)
+  uint16_t totalPages = 0;       // BookOrbitStatsQueue::PROGRESS_SCALE (self-describing per event)
+  uint16_t era = 0;              // WallClock power era the timestamp was taken in (truncated)
+  uint8_t flags = 0;             // FLAG_* bitmask
+  uint8_t reserved = 0;
+
+  static constexpr uint8_t FLAG_CLOCK_APPROXIMATE = 0x01;
+};
+static_assert(sizeof(BookOrbitStatEvent) == 16, "queue file records are raw 16-byte structs");
+
+/**
+ * On-SD queue of per-page reading events, one file per book in the book's cache
+ * directory (see docs/file-formats.md). The reader buffers events in RAM during a
+ * session and appends them as one batch when it closes (never once per page turn),
+ * and BookOrbitSyncActivity drains the file on the next successful sync.
+ */
+class BookOrbitStatsQueue {
+ public:
+  // Fixed denominator reported to the server as `totalPages`: positions are basis
+  // points, so page/totalPages reproduces the exact reading fraction.
+  static constexpr uint16_t PROGRESS_SCALE = 10000;
+
+  // Bounds the queue file so a never-synced device cannot grow it unbounded
+  // (2000 events = 32KB on SD and ~32KB heap when drained for upload). On overflow
+  // the OLDEST events are dropped: recent reading is worth more than old backlog.
+  static constexpr size_t MAX_QUEUED_EVENTS = 2000;
+
+  // Appends a batch of events to <bookCachePath>/bookorbit_stats.bin, dropping the
+  // oldest queued events if the cap would be exceeded. Returns false on storage
+  // failure. An empty batch is a no-op success.
+  static bool appendBatch(const std::string& bookCachePath, const std::vector<BookOrbitStatEvent>& events);
+
+  // Reads every queued event. Returns false on storage failure or a bad header;
+  // an absent file (or a discarded pre-v2 queue) yields true with an empty vector.
+  static bool readAll(const std::string& bookCachePath, std::vector<BookOrbitStatEvent>& outEvents);
+
+  // Removes the queue file (call after a fully successful upload).
+  static void clear(const std::string& bookCachePath);
+
+  // Number of events currently queued for the book (0 for absent/foreign files).
+  // Cheap size probe for diagnostics; does not load the events.
+  static size_t queuedCount(const std::string& bookCachePath);
+
+  // Captures the current UTC epoch for stamping a session. Prefers the DS3231 RTC
+  // (X3; exact), then the system clock kept by WallClock (X4; may be approximate).
+  // Sets `outApproximate` when the value may be offset from real time and should be
+  // corrected/qualified at upload. Returns false only when no usable clock exists
+  // at all (first-ever boot before any checkpoint or NTP) — the timestamp is still
+  // written and remains correctable within the same power era.
+  static bool captureNow(uint32_t& outEpochSeconds, bool& outApproximate);
+};

--- a/lib/BookOrbitSync/BookOrbitSyncClient.cpp
+++ b/lib/BookOrbitSync/BookOrbitSyncClient.cpp
@@ -493,6 +493,124 @@ BookOrbitSyncClient::Error BookOrbitSyncClient::updateProgress(const KOReaderPro
 #endif
 }
 
+BookOrbitSyncClient::Error BookOrbitSyncClient::uploadPageStats(const std::string& documentHash,
+                                                                const std::string& deviceModel,
+                                                                const BookOrbitStatEvent* events, size_t count) {
+  lastHttpCode = 0;
+  lastTransportError = 0;
+  if (!BOOKORBIT_STORE.hasCredentials()) {
+    LOG_DBG("BookOrbit", "No credentials configured");
+    return NO_CREDENTIALS;
+  }
+  if (!events || count == 0) {
+    return OK;
+  }
+
+  std::string url = BOOKORBIT_STORE.getBaseUrl() + "/plugin/page-stats";
+  const uint32_t freeHeap = ESP.getFreeHeap();
+  LOG_DBG("BookOrbit", "Uploading %u stat events: %s (heap: %u)", (unsigned)count, url.c_str(), (unsigned)freeHeap);
+  if (freeHeap < MIN_HEAP_FOR_TLS) {
+    LOG_ERR("BookOrbit", "Insufficient heap for TLS handshake: %u bytes free (need %u)", freeHeap, MIN_HEAP_FOR_TLS);
+    return LOW_MEMORY;
+  }
+
+  // Body shape mirrors BookOrbit's own KOReader plugin: device fields at the top
+  // level plus books[].hash and books[].events[].{page,startTime,durationSeconds,totalPages}.
+  // pluginVersion: the server caps this field at 20 characters and rejects the whole
+  // upload with HTTP 400 beyond that (verified against a live server by the samfoy
+  // fork). Never build it from CROSSINK_VERSION — variant/branch builds overflow
+  // (e.g. "crossink-1.4.0-xlarge" is 21 chars). Bump the numeric suffix when the
+  // payload shape changes.
+  // The JsonDocument is scoped so its node pool is freed before the TLS session
+  // starts: only the serialized body stays alive through the handshake.
+  std::string body;
+  {
+    JsonDocument doc;
+    doc["deviceId"] = DEVICE_ID;
+    doc["deviceModel"] = deviceModel;
+    doc["pluginVersion"] = "crossink-bo-1";
+    char deviceTime[20];
+    const time_t now = time(nullptr);
+    struct tm nowUtc = {};
+    gmtime_r(&now, &nowUtc);
+    strftime(deviceTime, sizeof(deviceTime), "%Y-%m-%d %H:%M:%S", &nowUtc);
+    doc["deviceTime"] = deviceTime;
+
+    JsonArray books = doc["books"].to<JsonArray>();
+    JsonObject book = books.add<JsonObject>();
+    book["hash"] = documentHash;
+    JsonArray jsonEvents = book["events"].to<JsonArray>();
+    for (size_t i = 0; i < count; i++) {
+      JsonObject event = jsonEvents.add<JsonObject>();
+      event["page"] = events[i].page;
+      event["startTime"] = events[i].startTime;
+      event["durationSeconds"] = events[i].durationSeconds;
+      event["totalPages"] = events[i].totalPages;
+    }
+    serializeJson(doc, body);
+  }
+
+#ifdef SIMULATOR
+  HTTPClient http;
+  std::unique_ptr<WiFiClientSecure> secureClient;
+  WiFiClient plainClient;
+
+  if (isHttpsUrl(url)) {
+    secureClient.reset(new WiFiClientSecure);
+    secureClient->setInsecure();
+    http.begin(*secureClient, url.c_str());
+  } else {
+    http.begin(plainClient, url.c_str());
+  }
+  addAuthHeaders(http);
+  http.addHeader("Content-Type", "application/json");
+
+  const int httpCode = http.POST(body.c_str());
+  lastHttpCode = httpCode;
+  lastTransportError = (httpCode < 0) ? httpCode : 0;
+  http.end();
+
+  LOG_DBG("BookOrbit", "Upload stats response: %d", httpCode);
+
+  if (httpCode >= 200 && httpCode < 300) return OK;
+  if (httpCode == 401) return AUTH_FAILED;
+  if (httpCode < 0) return NETWORK_ERROR;
+  return SERVER_ERROR;
+#else
+  ResponseBuffer buf;
+  logHeapStats("Before stats client", url.c_str());
+  esp_http_client_handle_t client = createClient(url.c_str(), &buf, HTTP_METHOD_POST);
+  if (!client) {
+    lastTransportError = ESP_ERR_NO_MEM;
+    return NETWORK_ERROR;
+  }
+
+  if (esp_http_client_set_header(client, "Content-Type", "application/json") != ESP_OK ||
+      esp_http_client_set_post_field(client, body.c_str(), body.length()) != ESP_OK) {
+    LOG_ERR("BookOrbit", "Failed to set request body");
+    lastTransportError = ESP_ERR_INVALID_STATE;
+    esp_http_client_cleanup(client);
+    return NETWORK_ERROR;
+  }
+
+  LOG_DBG("BookOrbit", "POST body bytes=%u", static_cast<unsigned>(body.length()));
+  logHeapStats("Before stats perform");
+  esp_err_t err = esp_http_client_perform(client);
+  const int httpCode = esp_http_client_get_status_code(client);
+  lastHttpCode = httpCode;
+  lastTransportError = static_cast<int>(err);
+  logHeapStats("After stats perform");
+  esp_http_client_cleanup(client);
+
+  LOG_DBG("BookOrbit", "Upload stats response: %d (err: %d)", httpCode, err);
+
+  if (err != ESP_OK) return NETWORK_ERROR;
+  if (httpCode >= 200 && httpCode < 300) return OK;
+  if (httpCode == 401) return AUTH_FAILED;
+  return SERVER_ERROR;
+#endif
+}
+
 std::string BookOrbitSyncClient::errorString(Error error) {
   switch (error) {
     case OK:

--- a/lib/BookOrbitSync/BookOrbitSyncClient.h
+++ b/lib/BookOrbitSync/BookOrbitSyncClient.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 
+#include "BookOrbitStatsQueue.h"
 #include "KOReaderSyncClient.h"
 
 /**
@@ -64,6 +65,19 @@ class BookOrbitSyncClient {
    * @return OK on success, error code on failure
    */
   static Error updateProgress(const KOReaderProgress& progress);
+
+  /**
+   * Upload queued reading-session events for one document to BookOrbit's
+   * page-stats endpoint (POST /plugin/page-stats). Upload-only: the endpoint has no
+   * download counterpart, so stats flow CrossInk -> BookOrbit.
+   * @param documentHash The binary partial-MD5 document hash
+   * @param deviceModel Human-readable device name reported alongside the stats
+   * @param events Events to upload (callers batch; keep each call small)
+   * @param count Number of events
+   * @return OK on success, error code on failure
+   */
+  static Error uploadPageStats(const std::string& documentHash, const std::string& deviceModel,
+                               const BookOrbitStatEvent* events, size_t count);
 
   /**
    * Get human-readable error message for the last error.

--- a/lib/WallClock/WallClock.cpp
+++ b/lib/WallClock/WallClock.cpp
@@ -1,0 +1,257 @@
+#include "WallClock.h"
+
+#include <HalStorage.h>
+#include <Logging.h>
+
+#include <cstring>
+#include <ctime>
+
+#ifndef SIMULATOR
+#include <sys/time.h>
+#endif
+
+namespace {
+constexpr char STATE_PATH[] = "/.crosspoint/wallclock.bin";
+// Bump this (and document the layout in docs/file-formats.md) if the record layout
+// changes: a file read under the wrong layout would mis-correct queued stats events,
+// which store a truncated era per record. An unknown magic is discarded, which restarts
+// era numbering — harmless as long as pending queues are drained first.
+constexpr char STATE_MAGIC[4] = {'W', 'C', 'K', '1'};
+
+// One NTP-measured era correction. Only eras where NTP actually ran appear in the
+// history ring: an era that never saw NTP has no measurable error.
+//
+// `delta` is the error measured at `syncDeviceEpoch` (the clock reading just before the
+// NTP sync). `windowStartEpoch` is the real time of the PREVIOUS sync in the same era,
+// when there was one: that sync set the clock exactly, so the error was zero at that
+// instant and grew to `delta` by `syncDeviceEpoch`. Those two points bound a drift ramp.
+// It stays 0 when the era opened with a clock loss, because then the error starts at the
+// unknown powered-off duration rather than at zero, and the ramp does not apply (see
+// correctionForEvent).
+struct EraCorrection {
+  uint32_t era = 0;
+  int64_t delta = 0;
+  uint32_t windowStartEpoch = 0;
+  uint32_t syncDeviceEpoch = 0;
+  bool used = false;
+};
+
+// RAM mirror of the persisted state. Power eras are keyed to CLOCK CONTINUITY, not to
+// RAM retention: the ESP32-C3's RTC memory does not reliably survive deep sleep on this
+// hardware (observed in the field: every wake bumped a RTC_NOINIT-based era), but the
+// system clock itself is restored/kept sane by initAtBoot. If the clock is plausible at
+// boot, timestamps continue the same timeline -> same era.
+struct WallClockState {
+  uint32_t era = 0;
+  uint32_t checkpointEpoch = 0;
+  EraCorrection history[WallClock::ERA_HISTORY];
+};
+WallClockState s_state;
+bool s_loaded = false;
+
+const EraCorrection* findCorrection(const WallClockState& state, const uint32_t era) {
+  for (size_t i = 0; i < WallClock::ERA_HISTORY; i++) {
+    if (state.history[i].used && state.history[i].era == era) return &state.history[i];
+  }
+  return nullptr;
+}
+
+void upsertIntoState(WallClockState& state, const EraCorrection& entry) {
+  // Update the era's existing slot, else replace the oldest (lowest era) entry.
+  size_t slot = 0;
+  uint32_t lowestEra = UINT32_MAX;
+  for (size_t i = 0; i < WallClock::ERA_HISTORY; i++) {
+    if (state.history[i].used && state.history[i].era == entry.era) {
+      slot = i;
+      break;
+    }
+    const uint32_t slotEra = state.history[i].used ? state.history[i].era : 0;
+    if (slotEra < lowestEra) {
+      lowestEra = slotEra;
+      slot = i;
+    }
+  }
+  state.history[slot] = entry;
+}
+
+bool plausible(uint64_t epoch) {
+  return epoch >= WallClock::MIN_PLAUSIBLE_EPOCH && epoch < WallClock::MAX_PLAUSIBLE_EPOCH;
+}
+
+bool loadState(WallClockState& out) {
+  if (!Storage.exists(STATE_PATH)) return false;
+  FsFile file;
+  if (!Storage.openFileForRead("CLK", STATE_PATH, file)) return false;
+
+  char magic[4];
+  uint8_t pad[3];
+  bool ok = file.read(magic, sizeof(magic)) == sizeof(magic) && memcmp(magic, STATE_MAGIC, sizeof(STATE_MAGIC)) == 0 &&
+            file.read(&out.era, sizeof(out.era)) == sizeof(out.era) &&
+            file.read(&out.checkpointEpoch, sizeof(out.checkpointEpoch)) == sizeof(out.checkpointEpoch);
+  for (size_t i = 0; ok && i < WallClock::ERA_HISTORY; i++) {
+    EraCorrection entry;
+    uint8_t used = 0;
+    ok = file.read(&entry.era, sizeof(entry.era)) == sizeof(entry.era) &&
+         file.read(&used, sizeof(used)) == sizeof(used) && file.read(pad, sizeof(pad)) == sizeof(pad) &&
+         file.read(&entry.delta, sizeof(entry.delta)) == sizeof(entry.delta) &&
+         file.read(&entry.windowStartEpoch, sizeof(entry.windowStartEpoch)) == sizeof(entry.windowStartEpoch) &&
+         file.read(&entry.syncDeviceEpoch, sizeof(entry.syncDeviceEpoch)) == sizeof(entry.syncDeviceEpoch);
+    if (ok && used != 0) {
+      entry.used = true;
+      upsertIntoState(out, entry);
+    }
+  }
+  file.close();
+  return ok;
+}
+
+void saveState() {
+  FsFile file;
+  if (!Storage.openFileForWrite("CLK", STATE_PATH, file)) {
+    LOG_ERR("CLK", "Failed to persist wall-clock state");
+    return;
+  }
+  const uint8_t pad[3] = {};
+  bool ok = file.write(STATE_MAGIC, sizeof(STATE_MAGIC)) == sizeof(STATE_MAGIC) &&
+            file.write(&s_state.era, sizeof(s_state.era)) == sizeof(s_state.era) &&
+            file.write(&s_state.checkpointEpoch, sizeof(s_state.checkpointEpoch)) == sizeof(s_state.checkpointEpoch);
+  for (size_t i = 0; ok && i < WallClock::ERA_HISTORY; i++) {
+    const EraCorrection& entry = s_state.history[i];
+    const uint8_t used = entry.used ? 1 : 0;
+    ok = file.write(&entry.era, sizeof(uint32_t)) == sizeof(uint32_t) &&
+         file.write(&used, sizeof(used)) == sizeof(used) && file.write(pad, sizeof(pad)) == sizeof(pad) &&
+         file.write(&entry.delta, sizeof(int64_t)) == sizeof(int64_t) &&
+         file.write(&entry.windowStartEpoch, sizeof(uint32_t)) == sizeof(uint32_t) &&
+         file.write(&entry.syncDeviceEpoch, sizeof(uint32_t)) == sizeof(uint32_t);
+  }
+  file.close();
+  if (!ok) {
+    LOG_ERR("CLK", "Failed to write wall-clock state");
+  }
+}
+}  // namespace
+
+void WallClock::initAtBoot() {
+  WallClockState persisted;
+  if (loadState(persisted)) {
+    s_state = persisted;
+  }
+  s_loaded = true;
+
+  const time_t now = time(nullptr);
+  if (plausible(static_cast<uint64_t>(now))) {
+    // The clock survived (soft reset, or a deep sleep that retained timekeeping): the
+    // timestamp timeline is continuous, so the era — and the correction anchors
+    // established in it — carry over.
+    LOG_INF("CLK", "Warm boot: era %u (synced=%d)", (unsigned)s_state.era,
+            findCorrection(s_state, s_state.era) != nullptr ? 1 : 0);
+    return;
+  }
+
+  // The clock was lost: a genuinely new timeline. Timestamps taken from here on are
+  // offset differently from real time than the previous era's, so corrections must not
+  // cross this boundary. The ending era's correction (if NTP ever measured it) already
+  // lives in the history ring for later resolution.
+  s_state.era++;
+  if (plausible(s_state.checkpointEpoch)) {
+#ifndef SIMULATOR
+    // Restore an approximate clock: correct except for the time spent powered off.
+    // NTP replaces it with exact time on the next network operation.
+    timeval tv = {};
+    tv.tv_sec = static_cast<time_t>(s_state.checkpointEpoch);
+    settimeofday(&tv, nullptr);
+#endif
+    LOG_INF("CLK", "Cold boot: clock restored from checkpoint %u (era %u)", (unsigned)s_state.checkpointEpoch,
+            (unsigned)s_state.era);
+  } else {
+    LOG_INF("CLK", "Cold boot: era %u, clock unset (no checkpoint)", (unsigned)s_state.era);
+  }
+  saveState();
+}
+
+void WallClock::checkpoint() {
+  const time_t now = time(nullptr);
+  if (!plausible(static_cast<uint64_t>(now))) {
+    LOG_DBG("CLK", "Skipping checkpoint: clock implausible");
+    return;
+  }
+  s_state.checkpointEpoch = static_cast<uint32_t>(now);
+  saveState();
+}
+
+void WallClock::markNtpSynced(const uint32_t epochBeforeSync) {
+  const time_t now = time(nullptr);
+  if (!plausible(static_cast<uint64_t>(now))) {
+    LOG_ERR("CLK", "NTP sync reported but clock still implausible");
+    return;
+  }
+  // The error the clock had accumulated by `epochBeforeSync`, which this sync just wiped
+  // out by setting the clock to real time.
+  const int64_t delta = static_cast<int64_t>(now) - static_cast<int64_t>(epochBeforeSync);
+
+  // A previous sync in this same era left the clock exact at its own instant, so the
+  // error ramped from 0 there to `delta` here and same-era timestamps in between can be
+  // interpolated. Without one, the era opened on a clock loss: the error starts at the
+  // unknown powered-off duration, so `delta` applies as a flat offset instead.
+  uint32_t windowStart = 0;
+  if (const EraCorrection* previous = findCorrection(s_state, s_state.era)) {
+    const int64_t previousSyncRealTime = static_cast<int64_t>(previous->syncDeviceEpoch) + previous->delta;
+    if (previous->syncDeviceEpoch != 0 && plausible(static_cast<uint64_t>(previousSyncRealTime))) {
+      windowStart = static_cast<uint32_t>(previousSyncRealTime);
+    }
+  }
+  upsertIntoState(s_state, {s_state.era, delta, windowStart, epochBeforeSync, true});
+  s_state.checkpointEpoch = static_cast<uint32_t>(now);
+  if (windowStart != 0) {
+    LOG_INF("CLK", "NTP confirmed (era %u, drift %+lld s over %u s since last sync)", (unsigned)s_state.era,
+            (long long)delta, (unsigned)(epochBeforeSync - windowStart));
+  } else {
+    LOG_INF("CLK", "NTP confirmed (era %u, correction %+lld s, flat)", (unsigned)s_state.era, (long long)delta);
+  }
+  saveState();
+}
+
+uint32_t WallClock::era() { return s_state.era; }
+
+bool WallClock::correctionForEvent(const uint16_t truncatedEra, const uint32_t recordedEpoch, int64_t& outDelta) {
+  if (!s_loaded) return false;
+  const EraCorrection* entry = nullptr;
+  for (size_t i = 0; i < ERA_HISTORY; i++) {
+    if (s_state.history[i].used && static_cast<uint16_t>(s_state.history[i].era) == truncatedEra) {
+      entry = &s_state.history[i];
+      break;
+    }
+  }
+  if (entry == nullptr) return false;
+
+  // Recorded after that sync set the clock to real time: already correct, bar the drift
+  // accrued since, which the next sync will measure and this one cannot know.
+  if (entry->syncDeviceEpoch != 0 && recordedEpoch > entry->syncDeviceEpoch) {
+    outDelta = 0;
+    return true;
+  }
+  // Era opened on a clock loss: the whole block shifts by the measured error, keeping
+  // the intervals between events intact.
+  if (entry->windowStartEpoch == 0 || entry->syncDeviceEpoch <= entry->windowStartEpoch) {
+    outDelta = entry->delta;
+    return true;
+  }
+  // Recorded before this drift window, so an earlier sync had already corrected it.
+  if (recordedEpoch <= entry->windowStartEpoch) {
+    outDelta = 0;
+    return true;
+  }
+  // Inside the window: the clock drifts at a near-constant rate (the RC oscillator's ppm
+  // error), so the error at `recordedEpoch` is the fraction of the window elapsed.
+  const int64_t window = static_cast<int64_t>(entry->syncDeviceEpoch) - static_cast<int64_t>(entry->windowStartEpoch);
+  const int64_t elapsed = static_cast<int64_t>(recordedEpoch) - static_cast<int64_t>(entry->windowStartEpoch);
+  const int64_t halfWindow = entry->delta >= 0 ? window / 2 : -(window / 2);
+  outDelta = (entry->delta * elapsed + halfWindow) / window;
+  return true;
+}
+
+bool WallClock::now(uint32_t& outEpochSeconds) {
+  const time_t now = time(nullptr);
+  outEpochSeconds = now > 0 ? static_cast<uint32_t>(now) : 0;
+  return plausible(static_cast<uint64_t>(now));
+}

--- a/lib/WallClock/WallClock.h
+++ b/lib/WallClock/WallClock.h
@@ -1,0 +1,80 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Best-effort wall-clock keeper for devices without a battery-backed RTC (X4).
+ *
+ * The ESP32-C3 system clock runs off the RTC timer, so it survives deep sleep and
+ * software resets; it is only lost on a true cold boot (power loss, brownout,
+ * flashing). This module layers two mechanisms on top:
+ *
+ *  - Checkpointing: whenever the clock is trustworthy (after NTP, at reading-session
+ *    ends), the current epoch is persisted to SD. On a cold boot the clock is
+ *    restored from that checkpoint, so it is only off by the time spent powered
+ *    down instead of starting at 1970.
+ *
+ *  - Power eras: a counter that increments whenever the clock is lost, so a queued
+ *    timestamp records which timeline it belongs to. Consumers that queue timestamped
+ *    records (e.g. BookOrbitStatsQueue) retroactively correct them to real time once
+ *    NTP runs, via correctionForEvent(). Within one era the clock only ever drifts
+ *    (any clock loss opens a new era), so the correction is either a drift ramp or a
+ *    flat shift — see correctionForEvent().
+ *
+ * On X3 hardware the DS3231 RTC remains the primary time source for reading-stats
+ * dates; this module still keeps the system clock sane for everything else.
+ */
+class WallClock {
+ public:
+  // Call once at boot after storage is ready. Detects cold boots (advances the era
+  // and, when the system clock is implausible, restores it from the checkpoint).
+  static void initAtBoot();
+
+  // Persist the current time as the boot-restore checkpoint. No-op (with a debug
+  // log) when the current time is implausible. Cheap: one small SD file write.
+  static void checkpoint();
+
+  // Record that NTP just set the system clock. `epochBeforeSync` is time(nullptr)
+  // captured immediately before the NTP sync; the difference to the corrected clock is
+  // the error the clock had accumulated, and the pair (epochBeforeSync, real time)
+  // anchors this era's correction. Also checkpoints.
+  static void markNtpSynced(uint32_t epochBeforeSync);
+
+  // Cold-boot counter. Wraps into uint16_t storage in queue records; wrap is
+  // harmless (eras only need to be distinguishable from their neighbours).
+  static uint32_t era();
+
+  // Number of past eras whose NTP-measured corrections are remembered (ring buffer
+  // in the persisted state). Eras that never saw NTP have no measurable correction
+  // and are never in the table.
+  static constexpr size_t ERA_HISTORY = 6;
+
+  // Seconds to add to a timestamp recorded in `truncatedEra` (as stored truncated in
+  // queue records) to get real time. Covers the current era and up to ERA_HISTORY
+  // confirmed past eras, so timestamps survive several clock losses between syncs.
+  // Returns false when that era's error was never measured.
+  //
+  // The clock's error has two sources, and the era tells them apart:
+  //
+  //  - Drift, always present: the RTC timer runs on the internal RC oscillator
+  //    (~3500 ppm, minutes per day). It accumulates in proportion to elapsed time, so
+  //    between two syncs in the SAME era the error ramps from 0 to the newly measured
+  //    value and is interpolated for each timestamp in between.
+  //  - Powered-off time, lost at each clock loss: the restored checkpoint is behind
+  //    real time by however long the device was off. That is a step, not a ramp, and it
+  //    is unknowable until the next sync — but it also opens a new era, so it never
+  //    lands inside a drift window. Those eras take the measured error as a FLAT shift,
+  //    which keeps the intervals between their events intact.
+  //
+  // Interpolating across a step would smear it over events on both sides, which is why
+  // this takes the timestamp and not just the era.
+  static bool correctionForEvent(uint16_t truncatedEra, uint32_t recordedEpoch, int64_t& outDelta);
+
+  // Current UTC epoch seconds, always returned (may be checkpoint-approximate or
+  // even 1970-based right after a first-ever cold boot). Returns false when the
+  // value is implausible (< 2020), true when plausible.
+  static bool now(uint32_t& outEpochSeconds);
+
+  static constexpr uint32_t MIN_PLAUSIBLE_EPOCH = 1577836800u;  // 2020-01-01
+  static constexpr uint32_t MAX_PLAUSIBLE_EPOCH = 4102444800u;  // 2100-01-01
+};

--- a/src/activities/reader/BookOrbitSyncActivity.cpp
+++ b/src/activities/reader/BookOrbitSyncActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Logging.h>
+#include <WallClock.h>
 #include <WiFi.h>
 #include <esp_sntp.h>
 #include <esp_wifi.h>
@@ -13,6 +14,7 @@
 #include <ctime>
 
 #include "BookOrbitCredentialStore.h"
+#include "BookOrbitStatsQueue.h"
 #include "CrossPointSettings.h"
 #include "Epub/Section.h"
 #include "EpubReaderUtils.h"
@@ -130,7 +132,12 @@ void BookOrbitSyncActivity::onWifiSelectionComplete(const bool success) {
   }
   requestUpdate(true);
 
+  // Capture the pre-NTP clock so WallClock can compute this power era's correction
+  // delta; queued stats stamped before this moment get fixed to exact time below.
+  uint32_t epochBeforeNtp = 0;
+  WallClock::now(epochBeforeNtp);
   syncTimeWithNTP();
+  WallClock::markNtpSynced(epochBeforeNtp);
 
   {
     RenderLock lock(*this);
@@ -175,6 +182,12 @@ void BookOrbitSyncActivity::performSync() {
   const auto result = BookOrbitSyncClient::getProgress(documentHash, remoteProgress);
   LOG_INF("BookOrbit", "Progress fetch result=%d (http=%d)", static_cast<int>(result),
           BookOrbitSyncClient::lastHttpCode);
+
+  // Progress fetch reaching the server (even with no stored progress) means auth and
+  // connectivity are good: piggyback the queued reading-session stats on this session.
+  if (result == BookOrbitSyncClient::OK || result == BookOrbitSyncClient::NOT_FOUND) {
+    uploadQueuedStats();
+  }
 
   if (result == BookOrbitSyncClient::NOT_FOUND) {
     {
@@ -268,6 +281,108 @@ void BookOrbitSyncActivity::performSync() {
     }
   }
   requestUpdate(true);
+}
+
+void BookOrbitSyncActivity::uploadQueuedStats() {
+  // Reading-session events queued by the reader (see BookOrbitStatsQueue), pushed
+  // while WiFi is already up for the progress sync. Upload-only: BookOrbit has no
+  // stats download API, so stats flow CrossInk -> BookOrbit.
+  std::vector<BookOrbitStatEvent> events;
+  const std::string cachePath = Epub::cachePathForFilePath(epubPath, "/.crosspoint");
+  if (!BookOrbitStatsQueue::readAll(cachePath, events) || events.empty()) {
+    LOG_INF("BookOrbit", "No queued reading stats for this book");
+    return;
+  }
+  LOG_INF("BookOrbit", "Draining %u queued events (era now %u)", (unsigned)events.size(), (unsigned)WallClock::era());
+  // Field-verifiable upload manifest: one line per event (post-correction, below)
+  // would miss the corrections, so log after the correction pass instead.
+
+  // Events stamped by the system clock (all of them on RTC-less devices) are
+  // re-resolved against NTP: each event gets the correction WallClock measured for ITS
+  // era, interpolated along the era's drift ramp when the clock ran continuously since
+  // the previous sync, or applied as a flat per-era shift when the era opened on a clock
+  // loss (see WallClock::correctionForEvent). The current era's anchors were refreshed
+  // by the NTP sync moments ago. Events from eras whose error was never measured keep
+  // their checkpoint-approximate stamp unless outright implausible.
+  uint32_t syncInstant = 0;                           // real time (NTP set the clock moments ago), 0 if it failed
+  if (!WallClock::now(syncInstant)) syncInstant = 0;  // implausible: no upper bound to enforce
+  size_t dropped = 0;
+  uint32_t previousStart = 0;
+  for (auto& event : events) {
+    if (event.flags & BookOrbitStatEvent::FLAG_CLOCK_APPROXIMATE) {
+      int64_t delta = 0;
+      if (WallClock::correctionForEvent(event.era, event.startTime, delta)) {
+        int64_t corrected = static_cast<int64_t>(event.startTime) + delta;
+        // Nothing queued can have happened after the sync that is uploading it, and the
+        // queue is chronological: keep both invariants whatever the measured error was.
+        if (syncInstant != 0 && corrected > static_cast<int64_t>(syncInstant)) corrected = syncInstant;
+        if (corrected < static_cast<int64_t>(previousStart)) corrected = previousStart;
+        if (corrected > 0 && corrected < static_cast<int64_t>(WallClock::MAX_PLAUSIBLE_EPOCH)) {
+          event.startTime = static_cast<uint32_t>(corrected);
+        }
+      } else if (event.startTime < WallClock::MIN_PLAUSIBLE_EPOCH) {
+        event.durationSeconds = 0;  // unresolvable (old era, never had a checkpoint): drop below
+        dropped++;
+      }
+    }
+    previousStart = event.startTime;
+  }
+  if (dropped > 0) {
+    events.erase(std::remove_if(events.begin(), events.end(),
+                                [](const BookOrbitStatEvent& e) { return e.durationSeconds == 0; }),
+                 events.end());
+    LOG_ERR("BookOrbit", "Dropped %u stat events with unresolvable timestamps", (unsigned)dropped);
+    if (events.empty()) {
+      BookOrbitStatsQueue::clear(cachePath);
+      return;
+    }
+  }
+
+  // Upload manifest: the corrected, as-sent timestamps, so "which session is
+  // missing" is answerable from serial logs. Capped to keep log volume sane.
+  constexpr size_t MAX_MANIFEST_LINES = 16;
+  const size_t manifestCount = std::min(events.size(), MAX_MANIFEST_LINES);
+  for (size_t i = 0; i < manifestCount; i++) {
+    char isoTime[24];
+    const time_t start = static_cast<time_t>(events[i].startTime);
+    struct tm startUtc = {};
+    gmtime_r(&start, &startUtc);
+    strftime(isoTime, sizeof(isoTime), "%Y-%m-%d %H:%M:%SZ", &startUtc);
+    LOG_INF("BookOrbit", "  event %u/%u: start=%s dur=%us pos=%u.%02u%%", (unsigned)(i + 1), (unsigned)events.size(),
+            isoTime, (unsigned)events[i].durationSeconds, (unsigned)(events[i].page / 100),
+            (unsigned)(events[i].page % 100));
+  }
+  if (events.size() > MAX_MANIFEST_LINES) {
+    LOG_INF("BookOrbit", "  ... %u more events", (unsigned)(events.size() - MAX_MANIFEST_LINES));
+  }
+
+  // Batch to keep each JSON body small (~100 events = ~7KB) next to the TLS buffers;
+  // the JsonDocument itself is freed before each TLS session starts (see client).
+  constexpr size_t BATCH_SIZE = 100;
+  for (size_t i = 0; i < events.size(); i += BATCH_SIZE) {
+    const size_t n = std::min(BATCH_SIZE, events.size() - i);
+    const auto result =
+        BookOrbitSyncClient::uploadPageStats(documentHash, SETTINGS.getEffectiveDeviceName(), &events[i], n);
+    if (result != BookOrbitSyncClient::OK) {
+      const int httpCode = BookOrbitSyncClient::lastHttpCode;
+      if (httpCode == 404 || httpCode == 405 || httpCode == 501) {
+        // Self-heal: this BookOrbit server predates the page-stats endpoint. Drop
+        // the queue instead of re-firing a doomed upload on every future sync;
+        // progress sync is unaffected. Updating the server starts buffering fresh.
+        LOG_INF("BookOrbit", "Server has no page-stats endpoint (http=%d); discarding queued stats", httpCode);
+        BookOrbitStatsQueue::clear(cachePath);
+        return;
+      }
+      // Transient failure: keep the whole queue for a later attempt; re-sending an
+      // already-accepted batch next time is harmless compared to losing sessions.
+      LOG_ERR("BookOrbit", "Stats upload failed after %u/%u events (http=%d)", (unsigned)i, (unsigned)events.size(),
+              httpCode);
+      return;
+    }
+  }
+
+  LOG_INF("BookOrbit", "Uploaded %u reading-session events", (unsigned)events.size());
+  BookOrbitStatsQueue::clear(cachePath);
 }
 
 void BookOrbitSyncActivity::performUpload() {

--- a/src/activities/reader/BookOrbitSyncActivity.h
+++ b/src/activities/reader/BookOrbitSyncActivity.h
@@ -92,6 +92,7 @@ class BookOrbitSyncActivity final : public Activity {
   void onWifiSelectionComplete(bool success);
   void performSync();
   void performUpload();
+  void uploadQueuedStats();
   bool consumeInitialConfirmRelease();
   void ensureEpubLoaded();
   void saveProgressAndReturn(const CrossPointPosition& position);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -11,6 +11,8 @@
 #include <Logging.h>
 #include <Memory.h>
 #include <MemoryBudget.h>
+#include <WallClock.h>
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -23,6 +25,7 @@
 #include "../settings/BookOrbitSettingsActivity.h"
 #include "../settings/KOReaderSettingsActivity.h"
 #include "BookOrbitCredentialStore.h"
+#include "BookOrbitStatsQueue.h"
 #include "BookOrbitSyncActivity.h"
 #include "BookStatsActivity.h"
 #include "ClipSelectionActivity.h"
@@ -1213,6 +1216,46 @@ bool EpubReaderActivity::currentPageReadingSecondsForStats(uint32_t& seconds, co
   return true;
 }
 
+void EpubReaderActivity::capturePageStatEvent(const uint32_t dwellSeconds) {
+  if (dwellSeconds == 0 || !epub || !section || section->pageCount <= 0) {
+    return;
+  }
+  if (!BOOKORBIT_STORE.hasCredentials()) {
+    return;
+  }
+  // Hard bound on session RAM (16 bytes per event); the SD queue applies the same
+  // cap with drop-oldest on flush.
+  if (pendingBookOrbitEvents.size() >= BookOrbitStatsQueue::MAX_QUEUED_EVENTS) {
+    return;
+  }
+
+  uint32_t nowEpoch = 0;
+  bool approximate = true;
+  BookOrbitStatsQueue::captureNow(nowEpoch, approximate);
+  if (nowEpoch == 0) {
+    return;  // no usable clock at all; same-era correction has nothing to anchor on
+  }
+
+  // Overall book position at the end of the page just finished, in basis points.
+  const float chapterProgress = static_cast<float>(section->currentPage + 1) / static_cast<float>(section->pageCount);
+  float overall = epub->calculateSizeProgress(currentSpineIndex, chapterProgress);
+  overall = std::min(1.0f, std::max(0.0f, overall));
+
+  BookOrbitStatEvent event;
+  event.startTime = nowEpoch > dwellSeconds ? nowEpoch - dwellSeconds : nowEpoch;
+  event.durationSeconds = std::min<uint32_t>(dwellSeconds, 86400u);
+  event.page = static_cast<uint16_t>(overall * BookOrbitStatsQueue::PROGRESS_SCALE + 0.5f);
+  event.totalPages = BookOrbitStatsQueue::PROGRESS_SCALE;
+  event.era = static_cast<uint16_t>(WallClock::era());
+  event.flags = approximate ? BookOrbitStatEvent::FLAG_CLOCK_APPROXIMATE : 0;
+
+  // Reserve in chunks so a long session doesn't realloc on every page turn.
+  if (pendingBookOrbitEvents.size() == pendingBookOrbitEvents.capacity()) {
+    pendingBookOrbitEvents.reserve(pendingBookOrbitEvents.size() + 64);
+  }
+  pendingBookOrbitEvents.push_back(event);
+}
+
 void EpubReaderActivity::recordCurrentPageReadingTime(const char* source) {
   if (activeFootnotePreview) {
     pageShownAtMs = 0UL;
@@ -1787,6 +1830,12 @@ void EpubReaderActivity::onEnter() {
   armReadingPaceWarmup("reader_open");
   sessionReadingSeconds = 0;
   hasSessionStartLocalDateTime = getCurrentLocalReadingStatsDateTime(sessionStartLocalDateTime);
+  if (BOOKORBIT_STORE.hasCredentials() && epub) {
+    // Diagnostic breadcrumb: shows whether previously queued sessions survived to
+    // this open — the key evidence when sessions go missing before a sync.
+    LOG_INF("BookOrbit", "Stats queue holds %u events at book open",
+            (unsigned)BookOrbitStatsQueue::queuedCount(epub->getCachePath()));
+  }
 
   globalStats = GlobalReadingStats::load();
 
@@ -1840,6 +1889,21 @@ void EpubReaderActivity::onExit() {
       recoverStoredPaceFromSession("reader_exit");
       refreshCachedTimeLeftEstimate();
       stats.save(epub->getCachePath());
+
+      // Flush the session's buffered per-page BookOrbit events in one batch (never
+      // once per page turn); drained on the next BookOrbit sync of this book.
+      if (!pendingBookOrbitEvents.empty()) {
+        BookOrbitStatsQueue::appendBatch(epub->getCachePath(), pendingBookOrbitEvents);
+        pendingBookOrbitEvents.clear();
+      } else if (BOOKORBIT_STORE.hasCredentials()) {
+        // A "vanished" session often never produced events at all: page turns only
+        // qualify with real dwell time, like the reading-pace stats.
+        LOG_INF("BookOrbit", "No qualifying page events this session (read %us)", (unsigned)elapsedSecs);
+      }
+
+      // Reading sessions are the natural "last known good time" checkpoints for the
+      // boot-time clock restore on RTC-less devices.
+      WallClock::checkpoint();
     }
     globalStats.save();
   }
@@ -3206,6 +3270,7 @@ void EpubReaderActivity::resetCurrentBookStatsAfterDelete() {
   sessionPaceSampleCount = 0;
   pendingReadFolderMove = false;
   hasSessionStartLocalDateTime = getCurrentLocalReadingStatsDateTime(sessionStartLocalDateTime);
+  pendingBookOrbitEvents.clear();
   armReadingPaceWarmup("book_stats_delete");
   initializeCompletionPromptTrigger();
 }
@@ -3758,6 +3823,12 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn, const char* source) {
     uint32_t forwardReadSeconds = 0;
     const bool shouldRecordForwardRead = forwardPageReadElapsed(forwardReadSeconds, source);
     recordCurrentPageReadingTime(source);
+    // Capture the BookOrbit page-stat event for the page being finished, using the
+    // position BEFORE the page/section mutation below (a chapter-exit turn resets
+    // `section`, which the capture needs).
+    if (shouldRecordForwardRead) {
+      capturePageStatEvent(forwardReadSeconds);
+    }
     const bool exitingChapter = section && section->pageCount > 0 && section->currentPage >= section->pageCount - 1;
     if (section->currentPage < section->pageCount - 1) {
       section->currentPage++;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <BookOrbitStatsQueue.h>
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
@@ -8,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "BookReadingStats.h"
 #include "BookmarkStore.h"
@@ -85,6 +87,9 @@ class EpubReaderActivity final : public Activity {
   GlobalReadingStats globalStats;
   ReadingStatsDateTime sessionStartLocalDateTime;
   bool hasSessionStartLocalDateTime = false;
+  // Per-page reading events buffered in RAM during the session and flushed to the
+  // book's BookOrbit stats queue on exit (never written once per page turn).
+  std::vector<BookOrbitStatEvent> pendingBookOrbitEvents;
   // Signals that the next render should reposition within the newly loaded section
   // based on a cross-book percentage jump.
   bool pendingPercentJump = false;
@@ -173,6 +178,7 @@ class EpubReaderActivity final : public Activity {
   bool currentPageReadingSecondsForStats(uint32_t& seconds, const char* source) const;
   void recordCurrentPageReadingTime(const char* source = "unknown");
   void recordForwardPagePaceSample(uint32_t seconds, const char* source);
+  void capturePageStatEvent(uint32_t dwellSeconds);
   bool getSessionAveragePaceSeconds(uint16_t& avgSeconds) const;
   void recoverStoredPaceFromSession(const char* reason = "unknown");
   bool getTimeLeftPaceSeconds(uint16_t& avgSeconds, const char*& source, uint16_t& sampleCount) const;

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -4,6 +4,7 @@
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Logging.h>
+#include <WallClock.h>
 #include <WiFi.h>
 #include <esp_sntp.h>
 #include <esp_wifi.h>
@@ -130,8 +131,12 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   }
   requestUpdate(true);
 
-  // Sync time with NTP before making API requests
+  // Sync time with NTP before making API requests; WallClock uses the pre/post
+  // difference to correct timestamps recorded earlier in this power era.
+  uint32_t epochBeforeNtp = 0;
+  WallClock::now(epochBeforeNtp);
   syncTimeWithNTP();
+  WallClock::markNtpSynced(epochBeforeNtp);
 
   {
     RenderLock lock(*this);
@@ -339,6 +344,7 @@ void KOReaderSyncActivity::performUpload() {
 
 void KOReaderSyncActivity::onEnter() {
   Activity::onEnter();
+  LOG_INF("KOSync", "KOReader sync starting");
   ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
   lockInitialConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <Logging.h>
 #include <SPI.h>
 #include <ScratchWorkspace.h>
+#include <WallClock.h>
 #include <builtinFonts/all.h>
 
 #ifdef SIMULATOR
@@ -641,6 +642,11 @@ void enterDeepSleep(bool fromTimeout) {
   deepSleepInProgress = true;
   activityManager.goToSleep(fromTimeout);
 
+  // Checkpoint the wall clock at the last possible moment: if deep sleep loses
+  // timekeeping on this hardware, the wake-time restore is then only off by the
+  // sleep duration instead of hours (see WallClock).
+  WallClock::checkpoint();
+
   if (isQuickResumeSleep) {
     saveSleepFrameBuffer();
   } else {
@@ -800,6 +806,9 @@ void setup() {
 
   SETTINGS.loadFromFile();
   Storage.installDateTimeCallback(&SETTINGS.clockUtcOffsetQ);
+  // Restore an approximate wall clock on cold boot (RTC-less devices) and track the
+  // power era used to correct queued reading-stats timestamps at sync time.
+  WallClock::initAtBoot();
   APP_STATE.loadFromFile();
   RECENT_BOOKS.loadFromFile();
   I18N.setLanguage(static_cast<Language>(SETTINGS.language));

--- a/src/util/BookCacheUtils.cpp
+++ b/src/util/BookCacheUtils.cpp
@@ -22,6 +22,7 @@ constexpr PreservedCacheFile EPUB_USER_STATE_FILES[] = {
     {"progress.bin", "upload_preserve_progress.bin"},
     {"progress.bin.bak", "upload_preserve_progress.bin.bak"},
     {"reader_settings.bin", "upload_preserve_reader_settings.bin"},
+    {"bookorbit_stats.bin", "upload_preserve_bookorbit_stats.bin"},
 };
 
 constexpr PreservedCacheFile PAGE_PROGRESS_FILES[] = {


### PR DESCRIPTION
## Summary

Upload one reading event per page read on every BookOrbit sync, feeding the server's reading time, streak and pace views the same way its KOReader plugin does. Events queue per book on the SD card, so reading offline loses nothing.

### Warning

Devices without a clock chip cannot timestamp them directly, since their clock stops at every sleep. A best-effort wall clock tracks which clock timeline each event belongs to, and every sync corrects the queued timestamps against the error it measures against NTP: spread as drift within a continuous timeline, applied as a block shift across a clock loss.


