### PR TITLE
fix: make the last home menu entry selectable on Classic and Lyra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ records only its own additions. Each release states the CrossInk version it is b
 on; for everything inherited from upstream, see the
 [CrossInk changelog](https://github.com/uxjulia/CrossInk/blob/main/CHANGELOG.md).
 
+## [Unreleased]
+
+### Fixed
+
+- The last entry of the home menu can be selected again on the Classic and Lyra themes. Navigation wrapped using a count maintained separately from the menu itself, and that count was never updated when the BookOrbit entry was added, so it stopped one position short — leaving Settings, which comes last, impossible to reach.
+
 ## [v1.4.1+bookorbit.2] - 2026-08-02
 
 Based on CrossInk v1.4.0.

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -597,23 +597,16 @@ static_assert(HomeActivity::kMaxCachedBooks >= LyraCarouselMetrics::values.homeR
               "kMaxCachedBooks must cover all carousel slots");
 
 int HomeActivity::getMenuItemCount() const {
+  // How many positions the selector can occupy: the selectable book rows, when the theme
+  // shows them separately, plus the menu itself.
+  //
+  // Counted from the very list that gets drawn rather than tallied by hand
   const auto& metrics = UITheme::getInstance().getMetrics();
-  int count = 4;  // File Browser, Recents, File transfer, Settings
-  if (!metrics.homeContinueReadingInMenu && !recentBooks.empty()) {
-    count += getVisibleRecentBookCount();
-  } else if (metrics.homeContinueReadingInMenu && !recentBooks.empty()) {
-    count++;  // Continue Reading menu item
-  }
-  if (hasOpdsServers) {
-    count++;
-  }
-  if (hasReadingStats) {
-    count++;
-  }
-  if (hasBookmarks || hasClippings) {
-    count++;
-  }
-  return count;
+  const bool includeContinueReading = metrics.homeContinueReadingInMenu && !recentBooks.empty();
+  const int bookRows = !metrics.homeContinueReadingInMenu && !recentBooks.empty() ? getVisibleRecentBookCount() : 0;
+  const HomeMenuEntries menuItems =
+      buildSelectableHomeMenuItems(hasOpdsServers, hasReadingStats, hasBookmarks, hasClippings, includeContinueReading);
+  return bookRows + menuItems.size();
 }
 
 void HomeActivity::loadRecentBooks(int maxBooks) {


### PR DESCRIPTION
Navigation on the non-carousel themes wrapped modulo getMenuItemCount(), a constant written by hand alongside the menu. Adding the BookOrbit entry to the menu left that tally untouched leading to the non-selectable last item

Derive the count from the list that is actually drawn


