### PR TITLE
Feat: Add lyra theme bookorbit browser + cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Based on CrossInk v1.5.0.
 
 ### Changed
 
+- The BookOrbit catalog browser now draws its lists with the active theme (contextual title in the header, author under each book title, on-device marker right-aligned), and scrolling past the bottom of a listing loads the next page in place of the previous "Previous page"/"Next page" entries. Listings already fetched during the session are kept on the SD card, so navigating back up re-opens them instantly instead of asking the server again (contributed by CaptainFrito).
 - A clipping saved with BookOrbit sync configured now stores the book's exact source text for the highlighted span (including the French non-breaking spaces before punctuation, kept as plain spaces). Clipping text used to be rebuilt from the rendered words, whose justified spacing could differ from the source ("mot ." for "mot.") -- visible in the clippings list and exports, and rejected by BookOrbit's text verification.
 - Saved highlights and clippings keep up to 2048 bytes of text (previously 512), so long web-created highlights survive sync in full. Downgrading to an older release after saving a longer one makes that older firmware treat the book's clippings file as corrupt and drop it.
 

--- a/src/activities/browser/BookOrbitCatalogBrowserActivity.cpp
+++ b/src/activities/browser/BookOrbitCatalogBrowserActivity.cpp
@@ -30,7 +30,6 @@
 #include "util/StringUtils.h"
 
 namespace {
-constexpr int PAGE_ITEMS = 23;
 constexpr size_t BOOKORBIT_DOWNLOAD_BUFFER_SIZE = 2048;
 constexpr char READ_FOLDER_PREFIX[] = "/Read";
 constexpr size_t MAX_LOCAL_ENTRIES = 200;
@@ -239,9 +238,15 @@ void BookOrbitCatalogBrowserActivity::loadLocalBooks(const std::string& kind) {
     });
   }
 
-  // Local listings behave like a book list one level below the root.
+  // Local listings behave like a book list one level below the root. Neutralise
+  // the paging context left by a previous server listing: without this, reaching
+  // the bottom of a local list could append SERVER results into it, and the
+  // scroll indicator would size itself on the stale server total.
   navLevel = NavLevel::Books;
   booksFromFacet = false;
+  listPage = 1;
+  listTotal = static_cast<int>(entries.size());
+  listPageSize = std::max<int>(1, static_cast<int>(entries.size()));
   selectorIndex = 0;
   state = entries.empty() ? BrowserState::ERROR : BrowserState::BROWSING;
   if (entries.empty()) errorMessage = tr(STR_NO_ENTRIES);
@@ -277,8 +282,8 @@ bool BookOrbitCatalogBrowserActivity::loadFacetEntries(const std::string& sectio
   if (!append) {
     entries.clear();
   }
-  std::sort(result.entries.begin(), result.entries.end(),
-            [](const auto& a, const auto& b) { return FsHelpers::naturalLess(a.title, b.title); });
+  // Server order is kept as-is: it is already alphabetical for facets, and a
+  // per-page sort would break the overall order once pages are appended.
   for (auto& facet : result.entries) {
     Entry entry;
     entry.type = EntryType::FACET;
@@ -331,11 +336,9 @@ bool BookOrbitCatalogBrowserActivity::loadBooks(const BookOrbitBookQuery& query,
   if (!append) {
     entries.clear();
   }
-  std::sort(result.books.begin(), result.books.end(), [](const auto& a, const auto& b) {
-    if (FsHelpers::naturalLess(a.title, b.title)) return true;
-    if (FsHelpers::naturalLess(b.title, a.title)) return false;
-    return FsHelpers::naturalLess(a.author, b.author);
-  });
+  // Server order carries the listing's meaning -- recency for "Continue reading"
+  // and "Recently added", series order for series -- and appending pages keeps
+  // it consistent; a client-side re-sort would destroy both.
   for (auto& book : result.books) {
     Entry entry;
     entry.type = EntryType::BOOK;
@@ -354,32 +357,25 @@ bool BookOrbitCatalogBrowserActivity::loadBooks(const BookOrbitBookQuery& query,
   return true;
 }
 
-bool BookOrbitCatalogBrowserActivity::appendNextPageForCurrentList(const size_t previousCount) {
+bool BookOrbitCatalogBrowserActivity::appendNextPageForCurrentList(const bool allowNetwork) {
+  const size_t previousCount = entries.size();
   if (navLevel == NavLevel::FacetList && facetHasNext) {
     if (!loadFacetEntries(facetSectionId, facetTitle, facetPage + 1, true, /*allowNetwork=*/false)) {
+      if (!allowNetwork) return false;
       showLoadingBeforeFetch();
       loadFacetEntries(facetSectionId, facetTitle, facetPage + 1, true);
     }
-    if (state == BrowserState::BROWSING && entries.size() > previousCount) {
-      selectorIndex = static_cast<int>(previousCount);
-      requestUpdate();
-      return true;
-    }
-    return false;
+    return state == BrowserState::BROWSING && entries.size() > previousCount;
   }
 
   const bool booksHasNext = static_cast<long>(listPage) * listPageSize < listTotal;
   if (navLevel == NavLevel::Books && booksHasNext) {
     if (!loadBooks(listQuery, listTitle, listPage + 1, booksFromFacet, true, /*allowNetwork=*/false)) {
+      if (!allowNetwork) return false;
       showLoadingBeforeFetch();
       loadBooks(listQuery, listTitle, listPage + 1, booksFromFacet, true);
     }
-    if (state == BrowserState::BROWSING && entries.size() > previousCount) {
-      selectorIndex = static_cast<int>(previousCount);
-      requestUpdate();
-      return true;
-    }
-    return false;
+    return state == BrowserState::BROWSING && entries.size() > previousCount;
   }
 
   return false;
@@ -657,27 +653,73 @@ void BookOrbitCatalogBrowserActivity::loop() {
     }
 
     if (!entries.empty()) {
-      const auto entryCount = entries.size();
-      buttonNavigator.onNextRelease([this, entryCount] {
-        if (selectorIndex + 1 >= static_cast<int>(entryCount) && appendNextPageForCurrentList(entryCount)) {
+      // Same rows-per-page the themed list draws, so page jumps land where the
+      // display pages; a fixed constant would drift from the theme's row height.
+      const int pageItems = listPageItems();
+      // More content on the server than is loaded? Then the loaded end is a
+      // phantom boundary mid-listing: never wrap onto or past it.
+      const auto hasMorePages = [this] {
+        if (navLevel == NavLevel::FacetList) return facetHasNext;
+        if (navLevel == NavLevel::Books) return static_cast<long>(listPage) * listPageSize < listTotal;
+        return false;
+      };
+      // Prefetch at the page turn: after a forward move onto the last loaded
+      // screen-page, append until that page is fully backed by loaded entries
+      // (server pages are not screen-page multiples, and can even be smaller
+      // than one screen). The load pause lands on a transition the e-ink
+      // refreshes anyway instead of mid-page, and the page comes up full. The
+      // lambdas read entries.size() live because appends grow the list.
+      const auto extendIfOnLastPage = [this, pageItems, hasMorePages] {
+        const int lastPageStart = (static_cast<int>(entries.size()) - 1) / pageItems * pageItems;
+        if (selectorIndex < lastPageStart) return;
+        const int wantedCount = (selectorIndex / pageItems + 1) * pageItems;
+        while (static_cast<int>(entries.size()) < wantedCount && hasMorePages()) {
+          if (!appendNextPageForCurrentList()) break;
+        }
+      };
+      buttonNavigator.onNextRelease([this, extendIfOnLastPage, hasMorePages] {
+        if (selectorIndex + 1 >= static_cast<int>(entries.size()) && hasMorePages() &&
+            !appendNextPageForCurrentList()) {
+          requestUpdate();  // could not load past the end (e.g. network); hold position, no wrap
           return;
         }
-        selectorIndex = ButtonNavigator::nextIndex(selectorIndex, entryCount);
+        selectorIndex = ButtonNavigator::nextIndex(selectorIndex, entries.size());
+        extendIfOnLastPage();
         requestUpdate();
       });
-      buttonNavigator.onPreviousRelease([this, entryCount] {
-        selectorIndex = ButtonNavigator::previousIndex(selectorIndex, entryCount);
+      // Backward from the very top: when the session cache holds the rest of the
+      // listing, materialise it (no requests) and wrap to the real end. A cache
+      // miss keeps the clamp -- a Previous press should not start a network crawl.
+      const auto materialiseFromCache = [this, hasMorePages] {
+        while (hasMorePages() && appendNextPageForCurrentList(/*allowNetwork=*/false)) {
+        }
+        return !hasMorePages();
+      };
+      buttonNavigator.onPreviousRelease([this, hasMorePages, materialiseFromCache] {
+        if (selectorIndex == 0 && hasMorePages() && !materialiseFromCache()) return;
+        selectorIndex = ButtonNavigator::previousIndex(selectorIndex, entries.size());
         requestUpdate();
       });
-      buttonNavigator.onNextContinuous([this, entryCount] {
-        if (selectorIndex + PAGE_ITEMS >= static_cast<int>(entryCount) && appendNextPageForCurrentList(entryCount)) {
+      buttonNavigator.onNextContinuous([this, pageItems, extendIfOnLastPage, hasMorePages] {
+        const int count = static_cast<int>(entries.size());
+        if (selectorIndex / pageItems == (count - 1) / pageItems && hasMorePages() && !appendNextPageForCurrentList()) {
+          requestUpdate();
           return;
         }
-        selectorIndex = ButtonNavigator::nextPageIndex(selectorIndex, entryCount, PAGE_ITEMS);
+        selectorIndex = ButtonNavigator::nextPageIndex(selectorIndex, entries.size(), pageItems);
+        extendIfOnLastPage();
         requestUpdate();
       });
-      buttonNavigator.onPreviousContinuous([this, entryCount] {
-        selectorIndex = ButtonNavigator::previousPageIndex(selectorIndex, entryCount, PAGE_ITEMS);
+      buttonNavigator.onPreviousContinuous([this, pageItems, hasMorePages, materialiseFromCache] {
+        if (selectorIndex / pageItems == 0 && hasMorePages()) {
+          if (selectorIndex > 0) {
+            selectorIndex = 0;  // finish the backward run at the top first
+            requestUpdate();
+            return;
+          }
+          if (!materialiseFromCache()) return;
+        }
+        selectorIndex = ButtonNavigator::previousPageIndex(selectorIndex, entries.size(), pageItems);
         requestUpdate();
       });
     }
@@ -751,12 +793,25 @@ void BookOrbitCatalogBrowserActivity::render(RenderLock&&) {
 
     const int contentTop = CompactHeader::contentTop(metrics);
     const int contentHeight = pageHeight - contentTop - metrics.buttonHintsHeight;
+    // The subtitle carries the author; without it two same-title search results
+    // are indistinguishable. Passing the lambda also selects the taller row
+    // height every themed list with subtitles uses.
+    // Book listings tell the scroll indicator the server's total, so its size
+    // and position are right from the first draw of a partially loaded list.
+    const int scrollTotal = navLevel == NavLevel::Books ? listTotal : -1;
     GUI.drawList(
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, entryCount, selectorIndex,
-        [this](int i) { return entries[i].title; },
-        nullptr,  // subtitle
+        [this](int i) { return entries[i].title; }, [this](int i) { return entries[i].subtitle; },
         nullptr,  // rowIcon
-        [this](int i) { return entries[i].onDevice ? ON_DEVICE_MARKER : ""; });
+        [this](int i) { return entries[i].onDevice ? ON_DEVICE_MARKER : ""; },
+        /*highlightValue=*/false, /*rowDimmed=*/nullptr, /*isHeader=*/nullptr, /*rowHeightScale=*/1,
+        /*showSelection=*/true, scrollTotal);
   }
   renderer.displayBuffer();
+}
+
+int BookOrbitCatalogBrowserActivity::listPageItems() const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const int contentHeight = renderer.getScreenHeight() - CompactHeader::contentTop(metrics) - metrics.buttonHintsHeight;
+  return std::max(1, GUI.getListPageItems(contentHeight, /*hasSubtitle=*/true));
 }

--- a/src/activities/browser/BookOrbitCatalogBrowserActivity.cpp
+++ b/src/activities/browser/BookOrbitCatalogBrowserActivity.cpp
@@ -12,6 +12,7 @@
 #include <cctype>
 #include <cstring>
 
+#include "./BookOrbitCatalogListCache.h"
 #include "BookOrbitCredentialStore.h"
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
@@ -21,6 +22,7 @@
 #include "activities/network/WifiSelectionActivity.h"
 #include "activities/reader/BookReadingStats.h"
 #include "activities/util/KeyboardEntryActivity.h"
+#include "components/CompactHeader.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
@@ -76,6 +78,7 @@ void BookOrbitCatalogBrowserActivity::onEnter() {
   consumeConfirm = false;
   errorMessage.clear();
   statusMessage = tr(STR_CHECKING_WIFI);
+  BookOrbitCatalogListCache::clear();
 
   if (!BOOKORBIT_STORE.hasCredentials()) {
     state = BrowserState::ERROR;
@@ -120,8 +123,10 @@ void BookOrbitCatalogBrowserActivity::onWifiSelectionComplete(const bool connect
     return;
   }
   sdFontSystem.releaseForNetwork(renderer);
-  showLoadingBeforeFetch();
-  loadRoot();
+  if (!loadRoot(/*allowNetwork=*/false)) {
+    showLoadingBeforeFetch();
+    loadRoot();
+  }
 }
 
 void BookOrbitCatalogBrowserActivity::showLoadingBeforeFetch() {
@@ -133,15 +138,22 @@ void BookOrbitCatalogBrowserActivity::showLoadingBeforeFetch() {
   }
 }
 
-void BookOrbitCatalogBrowserActivity::loadRoot() {
+bool BookOrbitCatalogBrowserActivity::loadRoot(const bool allowNetwork) {
   navLevel = NavLevel::Root;
   std::vector<BookOrbitCatalogSection> sections;
-  if (!BookOrbitCatalogClient::fetchRootSections(sections)) {
+  const bool cacheHit = BookOrbitCatalogListCache::loadRootSections(sections);
+  if (!cacheHit && !allowNetwork) {
+    return false;
+  }
+  if (!cacheHit && !BookOrbitCatalogClient::fetchRootSections(sections)) {
     state = BrowserState::ERROR;
     errorMessage = BookOrbitCatalogClient::lastFetchBadResponse ? tr(STR_BOOKORBIT_CATALOG_BAD_RESPONSE)
                                                                 : tr(STR_BOOKORBIT_CATALOG_ERROR);
     requestUpdate();
-    return;
+    return false;
+  }
+  if (!cacheHit) {
+    BookOrbitCatalogListCache::saveRootSections(sections);
   }
 
   entries.clear();
@@ -173,10 +185,12 @@ void BookOrbitCatalogBrowserActivity::loadRoot() {
   state = entries.empty() ? BrowserState::ERROR : BrowserState::BROWSING;
   if (entries.empty()) errorMessage = tr(STR_NO_ENTRIES);
   requestUpdate();
+  return true;
 }
 
 void BookOrbitCatalogBrowserActivity::loadLocalBooks(const std::string& kind) {
   entries.clear();
+  listTitle = (kind == "in-progress") ? tr(STR_BOOKORBIT_IN_PROGRESS) : tr(STR_BOOKORBIT_ON_DEVICE);
 
   if (kind == "in-progress") {
     // Books with local reading progress: the recent-books list minus finished ones.
@@ -191,6 +205,11 @@ void BookOrbitCatalogBrowserActivity::loadLocalBooks(const std::string& kind) {
       entry.path = book.path;
       entries.push_back(std::move(entry));
     }
+    std::sort(entries.begin(), entries.end(), [](const Entry& a, const Entry& b) {
+      if (FsHelpers::naturalLess(a.title, b.title)) return true;
+      if (FsHelpers::naturalLess(b.title, a.title)) return false;
+      return FsHelpers::naturalLess(a.subtitle, b.subtitle);
+    });
   } else {
     // Every EPUB in the download location and the /Read folder, offline.
     const auto scanDir = [this](const char* dirPath) {
@@ -213,7 +232,11 @@ void BookOrbitCatalogBrowserActivity::loadLocalBooks(const std::string& kind) {
     };
     scanDir("/");
     scanDir(READ_FOLDER_PREFIX);
-    std::sort(entries.begin(), entries.end(), [](const Entry& a, const Entry& b) { return a.title < b.title; });
+    std::sort(entries.begin(), entries.end(), [](const Entry& a, const Entry& b) {
+      if (FsHelpers::naturalLess(a.title, b.title)) return true;
+      if (FsHelpers::naturalLess(b.title, a.title)) return false;
+      return FsHelpers::naturalLess(a.subtitle, b.subtitle);
+    });
   }
 
   // Local listings behave like a book list one level below the root.
@@ -225,15 +248,22 @@ void BookOrbitCatalogBrowserActivity::loadLocalBooks(const std::string& kind) {
   requestUpdate();
 }
 
-void BookOrbitCatalogBrowserActivity::loadFacetEntries(const std::string& sectionId, const std::string& title,
-                                                       const int page) {
+bool BookOrbitCatalogBrowserActivity::loadFacetEntries(const std::string& sectionId, const std::string& title,
+                                                       const int page, const bool append, const bool allowNetwork) {
   BookOrbitFacetPage result;
-  if (!BookOrbitCatalogClient::fetchSectionEntries(sectionId, page, result)) {
+  const bool cacheHit = BookOrbitCatalogListCache::loadFacetPage(sectionId, page, result);
+  if (!cacheHit && !allowNetwork) {
+    return false;
+  }
+  if (!cacheHit && !BookOrbitCatalogClient::fetchSectionEntries(sectionId, page, result)) {
     state = BrowserState::ERROR;
     errorMessage = BookOrbitCatalogClient::lastFetchBadResponse ? tr(STR_BOOKORBIT_CATALOG_BAD_RESPONSE)
                                                                 : tr(STR_BOOKORBIT_CATALOG_ERROR);
     requestUpdate();
-    return;
+    return false;
+  }
+  if (!cacheHit) {
+    BookOrbitCatalogListCache::saveFacetPage(sectionId, page, result);
   }
 
   // Commit the navigation context only on success, so a failed page fetch leaves
@@ -244,13 +274,11 @@ void BookOrbitCatalogBrowserActivity::loadFacetEntries(const std::string& sectio
   facetPage = page;
   facetHasNext = result.hasNext;
 
-  entries.clear();
-  if (page > 1) {
-    Entry prev;
-    prev.type = EntryType::PREV_PAGE;
-    prev.title = tr(STR_PREV_PAGE);
-    entries.push_back(std::move(prev));
+  if (!append) {
+    entries.clear();
   }
+  std::sort(result.entries.begin(), result.entries.end(),
+            [](const auto& a, const auto& b) { return FsHelpers::naturalLess(a.title, b.title); });
   for (auto& facet : result.entries) {
     Entry entry;
     entry.type = EntryType::FACET;
@@ -262,28 +290,32 @@ void BookOrbitCatalogBrowserActivity::loadFacetEntries(const std::string& sectio
     entry.seriesId = facet.seriesId;
     entries.push_back(std::move(entry));
   }
-  if (facetHasNext) {
-    Entry next;
-    next.type = EntryType::NEXT_PAGE;
-    next.title = tr(STR_NEXT_PAGE);
-    entries.push_back(std::move(next));
+  if (!append) {
+    selectorIndex = 0;
   }
-
-  selectorIndex = 0;
   state = entries.empty() ? BrowserState::ERROR : BrowserState::BROWSING;
   if (entries.empty()) errorMessage = tr(STR_NO_ENTRIES);
   requestUpdate();
+  return true;
 }
 
-void BookOrbitCatalogBrowserActivity::loadBooks(const BookOrbitBookQuery& query, const std::string& title,
-                                                const int page, const bool fromFacet) {
+bool BookOrbitCatalogBrowserActivity::loadBooks(const BookOrbitBookQuery& query, const std::string& title,
+                                                const int page, const bool fromFacet, const bool append,
+                                                const bool allowNetwork) {
   BookOrbitBookPage result;
-  if (!BookOrbitCatalogClient::fetchBooks(query, page, result)) {
+  const bool cacheHit = BookOrbitCatalogListCache::loadBooksPage(query, page, result);
+  if (!cacheHit && !allowNetwork) {
+    return false;
+  }
+  if (!cacheHit && !BookOrbitCatalogClient::fetchBooks(query, page, result)) {
     state = BrowserState::ERROR;
     errorMessage = BookOrbitCatalogClient::lastFetchBadResponse ? tr(STR_BOOKORBIT_CATALOG_BAD_RESPONSE)
                                                                 : tr(STR_BOOKORBIT_CATALOG_ERROR);
     requestUpdate();
-    return;
+    return false;
+  }
+  if (!cacheHit) {
+    BookOrbitCatalogListCache::saveBooksPage(query, page, result);
   }
 
   // Commit the navigation context only on success (see loadFacetEntries).
@@ -296,13 +328,14 @@ void BookOrbitCatalogBrowserActivity::loadBooks(const BookOrbitBookQuery& query,
   listTotal = result.total;
   listPageSize = result.pageSize > 0 ? result.pageSize : BookOrbitCatalogClient::PAGE_SIZE;
 
-  entries.clear();
-  if (page > 1) {
-    Entry prev;
-    prev.type = EntryType::PREV_PAGE;
-    prev.title = tr(STR_PREV_PAGE);
-    entries.push_back(std::move(prev));
+  if (!append) {
+    entries.clear();
   }
+  std::sort(result.books.begin(), result.books.end(), [](const auto& a, const auto& b) {
+    if (FsHelpers::naturalLess(a.title, b.title)) return true;
+    if (FsHelpers::naturalLess(b.title, a.title)) return false;
+    return FsHelpers::naturalLess(a.author, b.author);
+  });
   for (auto& book : result.books) {
     Entry entry;
     entry.type = EntryType::BOOK;
@@ -312,18 +345,44 @@ void BookOrbitCatalogBrowserActivity::loadBooks(const BookOrbitBookQuery& query,
     entry.onDevice = bookOnDevice(book.title, book.author);
     entries.push_back(std::move(entry));
   }
-  const bool hasNext = static_cast<long>(page) * listPageSize < listTotal;
-  if (hasNext) {
-    Entry next;
-    next.type = EntryType::NEXT_PAGE;
-    next.title = tr(STR_NEXT_PAGE);
-    entries.push_back(std::move(next));
+  if (!append) {
+    selectorIndex = 0;
   }
-
-  selectorIndex = 0;
   state = entries.empty() ? BrowserState::ERROR : BrowserState::BROWSING;
   if (entries.empty()) errorMessage = tr(STR_NO_ENTRIES);
   requestUpdate();
+  return true;
+}
+
+bool BookOrbitCatalogBrowserActivity::appendNextPageForCurrentList(const size_t previousCount) {
+  if (navLevel == NavLevel::FacetList && facetHasNext) {
+    if (!loadFacetEntries(facetSectionId, facetTitle, facetPage + 1, true, /*allowNetwork=*/false)) {
+      showLoadingBeforeFetch();
+      loadFacetEntries(facetSectionId, facetTitle, facetPage + 1, true);
+    }
+    if (state == BrowserState::BROWSING && entries.size() > previousCount) {
+      selectorIndex = static_cast<int>(previousCount);
+      requestUpdate();
+      return true;
+    }
+    return false;
+  }
+
+  const bool booksHasNext = static_cast<long>(listPage) * listPageSize < listTotal;
+  if (navLevel == NavLevel::Books && booksHasNext) {
+    if (!loadBooks(listQuery, listTitle, listPage + 1, booksFromFacet, true, /*allowNetwork=*/false)) {
+      showLoadingBeforeFetch();
+      loadBooks(listQuery, listTitle, listPage + 1, booksFromFacet, true);
+    }
+    if (state == BrowserState::BROWSING && entries.size() > previousCount) {
+      selectorIndex = static_cast<int>(previousCount);
+      requestUpdate();
+      return true;
+    }
+    return false;
+  }
+
+  return false;
 }
 
 void BookOrbitCatalogBrowserActivity::launchSearch() {
@@ -348,11 +407,13 @@ void BookOrbitCatalogBrowserActivity::performSearch(const std::string& query) {
     requestUpdate();
     return;
   }
-  showLoadingBeforeFetch();
   BookOrbitBookQuery bookQuery;
   bookQuery.sort = "title";
   bookQuery.query = query;
-  loadBooks(bookQuery, query, 1, /*fromFacet=*/false);
+  if (!loadBooks(bookQuery, query, 1, /*fromFacet=*/false, /*append=*/false, /*allowNetwork=*/false)) {
+    showLoadingBeforeFetch();
+    loadBooks(bookQuery, query, 1, /*fromFacet=*/false);
+  }
 }
 
 void BookOrbitCatalogBrowserActivity::downloadBook(const int64_t bookId, const std::string& title) {
@@ -440,14 +501,18 @@ void BookOrbitCatalogBrowserActivity::downloadBook(const int64_t bookId, const s
     clearBookCache(filename);
     // The listing was freed for download headroom; rebuild it from the stored
     // context so the user returns to the same page.
-    showLoadingBeforeFetch();
-    loadBooks(listQuery, listTitle, listPage, booksFromFacet);
+    if (!loadBooks(listQuery, listTitle, listPage, booksFromFacet, /*append=*/false, /*allowNetwork=*/false)) {
+      showLoadingBeforeFetch();
+      loadBooks(listQuery, listTitle, listPage, booksFromFacet);
+    }
     return;
   } else if (result == HttpDownloader::ABORTED) {
     LOG_DBG("BookOrbit", "Download cancelled");
     mappedInput.suppressNextBackRelease();
-    showLoadingBeforeFetch();
-    loadBooks(listQuery, listTitle, listPage, booksFromFacet);
+    if (!loadBooks(listQuery, listTitle, listPage, booksFromFacet, /*append=*/false, /*allowNetwork=*/false)) {
+      showLoadingBeforeFetch();
+      loadBooks(listQuery, listTitle, listPage, booksFromFacet);
+    }
     return;
   } else {
     state = BrowserState::ERROR;
@@ -490,11 +555,17 @@ void BookOrbitCatalogBrowserActivity::loop() {
         onGoHome();
       } else if (entries.empty()) {
         // The listing was freed for a download that then failed; rebuild it.
-        showLoadingBeforeFetch();
         if (navLevel == NavLevel::FacetList) {
-          loadFacetEntries(facetSectionId, facetTitle, facetPage);
+          if (!loadFacetEntries(facetSectionId, facetTitle, facetPage, /*append=*/false, /*allowNetwork=*/false)) {
+            showLoadingBeforeFetch();
+            loadFacetEntries(facetSectionId, facetTitle, facetPage);
+          }
         } else {
-          loadBooks(listQuery, listTitle, listPage, booksFromFacet);
+          if (!loadBooks(listQuery, listTitle, listPage, booksFromFacet, /*append=*/false,
+                         /*allowNetwork=*/false)) {
+            showLoadingBeforeFetch();
+            loadBooks(listQuery, listTitle, listPage, booksFromFacet);
+          }
         }
       } else {
         state = BrowserState::BROWSING;
@@ -519,17 +590,21 @@ void BookOrbitCatalogBrowserActivity::loop() {
         const auto& entry = entries[selectorIndex];
         switch (entry.type) {
           case EntryType::SECTION: {
-            showLoadingBeforeFetch();
             BookOrbitBookQuery query;
             query.sort = entry.sectionId == "continue-reading" ? "recently_read"
                          : entry.sectionId == "all-books"      ? "title"
                                                                : "recently_added";
-            loadBooks(query, entry.title, 1, /*fromFacet=*/false);
+            if (!loadBooks(query, entry.title, 1, /*fromFacet=*/false, /*append=*/false, /*allowNetwork=*/false)) {
+              showLoadingBeforeFetch();
+              loadBooks(query, entry.title, 1, /*fromFacet=*/false);
+            }
             break;
           }
           case EntryType::FACET_SECTION:
-            showLoadingBeforeFetch();
-            loadFacetEntries(entry.sectionId, entry.title, 1);
+            if (!loadFacetEntries(entry.sectionId, entry.title, 1, /*append=*/false, /*allowNetwork=*/false)) {
+              showLoadingBeforeFetch();
+              loadFacetEntries(entry.sectionId, entry.title, 1);
+            }
             break;
           case EntryType::LOCAL_SECTION:
             loadLocalBooks(entry.sectionId);
@@ -538,7 +613,6 @@ void BookOrbitCatalogBrowserActivity::loop() {
             activityManager.goToReader(entry.path);
             break;
           case EntryType::FACET: {
-            showLoadingBeforeFetch();
             // Mirror BookOrbit's own plugin: author filters by the entry id; series
             // prefers the numeric seriesId and sorts by series order.
             BookOrbitBookQuery query;
@@ -552,7 +626,10 @@ void BookOrbitCatalogBrowserActivity::loop() {
             } else {
               query.author = entry.sectionId;
             }
-            loadBooks(query, entry.title, 1, /*fromFacet=*/true);
+            if (!loadBooks(query, entry.title, 1, /*fromFacet=*/true, /*append=*/false, /*allowNetwork=*/false)) {
+              showLoadingBeforeFetch();
+              loadBooks(query, entry.title, 1, /*fromFacet=*/true);
+            }
             break;
           }
           case EntryType::SEARCH:
@@ -561,39 +638,30 @@ void BookOrbitCatalogBrowserActivity::loop() {
           case EntryType::BOOK:
             downloadBook(entry.bookId, entry.title);
             break;
-          case EntryType::PREV_PAGE:
-            showLoadingBeforeFetch();
-            if (navLevel == NavLevel::FacetList) {
-              loadFacetEntries(facetSectionId, facetTitle, facetPage - 1);
-            } else {
-              loadBooks(listQuery, listTitle, listPage - 1, booksFromFacet);
-            }
-            break;
-          case EntryType::NEXT_PAGE:
-            showLoadingBeforeFetch();
-            if (navLevel == NavLevel::FacetList) {
-              loadFacetEntries(facetSectionId, facetTitle, facetPage + 1);
-            } else {
-              loadBooks(listQuery, listTitle, listPage + 1, booksFromFacet);
-            }
-            break;
         }
       }
     } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       if (navLevel == NavLevel::Root) {
         onGoHome();
       } else if (navLevel == NavLevel::Books && booksFromFacet) {
-        showLoadingBeforeFetch();
-        loadFacetEntries(facetSectionId, facetTitle, facetPage);
+        if (!loadFacetEntries(facetSectionId, facetTitle, facetPage, /*append=*/false, /*allowNetwork=*/false)) {
+          showLoadingBeforeFetch();
+          loadFacetEntries(facetSectionId, facetTitle, facetPage);
+        }
       } else {
-        showLoadingBeforeFetch();
-        loadRoot();
+        if (!loadRoot(/*allowNetwork=*/false)) {
+          showLoadingBeforeFetch();
+          loadRoot();
+        }
       }
     }
 
     if (!entries.empty()) {
       const auto entryCount = entries.size();
       buttonNavigator.onNextRelease([this, entryCount] {
+        if (selectorIndex + 1 >= static_cast<int>(entryCount) && appendNextPageForCurrentList(entryCount)) {
+          return;
+        }
         selectorIndex = ButtonNavigator::nextIndex(selectorIndex, entryCount);
         requestUpdate();
       });
@@ -602,6 +670,9 @@ void BookOrbitCatalogBrowserActivity::loop() {
         requestUpdate();
       });
       buttonNavigator.onNextContinuous([this, entryCount] {
+        if (selectorIndex + PAGE_ITEMS >= static_cast<int>(entryCount) && appendNextPageForCurrentList(entryCount)) {
+          return;
+        }
         selectorIndex = ButtonNavigator::nextPageIndex(selectorIndex, entryCount, PAGE_ITEMS);
         requestUpdate();
       });
@@ -615,10 +686,18 @@ void BookOrbitCatalogBrowserActivity::loop() {
 
 void BookOrbitCatalogBrowserActivity::render(RenderLock&&) {
   renderer.clearScreen();
+
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
+  const auto& metrics = UITheme::getInstance().getMetrics();
 
-  renderer.drawCenteredText(UI_12_FONT_ID, 15, tr(STR_BOOKORBIT_CATALOG), true, EpdFontFamily::BOLD);
+  std::string headerTitle = tr(STR_BOOKORBIT_CATALOG);
+  if (navLevel == NavLevel::FacetList && !facetTitle.empty()) {
+    headerTitle = facetTitle;
+  } else if (navLevel == NavLevel::Books && !listTitle.empty()) {
+    headerTitle = listTitle;
+  }
+  CompactHeader::drawTitle(renderer, headerTitle.c_str());
 
   if (state == BrowserState::CHECK_WIFI || state == BrowserState::LOADING) {
     renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2, statusMessage.c_str());
@@ -668,25 +747,16 @@ void BookOrbitCatalogBrowserActivity::render(RenderLock&&) {
   if (entries.empty()) {
     renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2, tr(STR_NO_ENTRIES));
   } else {
-    const auto entryCount = entries.size();
-    const auto pageStartIndex = selectorIndex / PAGE_ITEMS * PAGE_ITEMS;
-    renderer.fillRect(0, 60 + (selectorIndex % PAGE_ITEMS) * 30 - 2, pageWidth - 1, 30);
+    const auto entryCount = static_cast<int>(entries.size());
 
-    for (size_t i = pageStartIndex; i < entryCount && i < static_cast<size_t>(pageStartIndex + PAGE_ITEMS); i++) {
-      const auto& entry = entries[i];
-      const bool isBookRow = entry.type == EntryType::BOOK || entry.type == EntryType::LOCAL_BOOK;
-      std::string displayText = isBookRow ? entry.title : "> " + entry.title;
-      if (isBookRow && !entry.subtitle.empty()) displayText += " - " + entry.subtitle;
-      // Keep the right edge clear for the on-device marker on catalog rows.
-      const int textWidth = entry.onDevice ? pageWidth - 60 : pageWidth - 40;
-      auto item = renderer.truncatedText(UI_10_FONT_ID, displayText.c_str(), textWidth);
-      const int rowY = 60 + (i % PAGE_ITEMS) * 30;
-      const bool inverted = i != static_cast<size_t>(selectorIndex);
-      renderer.drawText(UI_10_FONT_ID, 20, rowY, item.c_str(), inverted);
-      if (entry.onDevice) {
-        renderer.drawText(UI_10_FONT_ID, pageWidth - 32, rowY, ON_DEVICE_MARKER, inverted);
-      }
-    }
+    const int contentTop = CompactHeader::contentTop(metrics);
+    const int contentHeight = pageHeight - contentTop - metrics.buttonHintsHeight;
+    GUI.drawList(
+        renderer, Rect{0, contentTop, pageWidth, contentHeight}, entryCount, selectorIndex,
+        [this](int i) { return entries[i].title; },
+        nullptr,  // subtitle
+        nullptr,  // rowIcon
+        [this](int i) { return entries[i].onDevice ? ON_DEVICE_MARKER : ""; });
   }
   renderer.displayBuffer();
 }

--- a/src/activities/browser/BookOrbitCatalogBrowserActivity.h
+++ b/src/activities/browser/BookOrbitCatalogBrowserActivity.h
@@ -80,7 +80,8 @@ class BookOrbitCatalogBrowserActivity final : public Activity {
                         bool allowNetwork = true);
   bool loadBooks(const BookOrbitBookQuery& query, const std::string& title, int page, bool fromFacet,
                  bool append = false, bool allowNetwork = true);
-  bool appendNextPageForCurrentList(size_t previousCount);
+  bool appendNextPageForCurrentList(bool allowNetwork = true);
+  int listPageItems() const;
   void launchSearch();
   void performSearch(const std::string& query);
   void downloadBook(int64_t bookId, const std::string& title);

--- a/src/activities/browser/BookOrbitCatalogBrowserActivity.h
+++ b/src/activities/browser/BookOrbitCatalogBrowserActivity.h
@@ -19,7 +19,7 @@
 class BookOrbitCatalogBrowserActivity final : public Activity {
  public:
   enum class BrowserState { CHECK_WIFI, WIFI_SELECTION, LOADING, BROWSING, DOWNLOADING, ERROR, SEARCH_INPUT };
-  enum class EntryType { SECTION, FACET_SECTION, FACET, LOCAL_SECTION, LOCAL_BOOK, SEARCH, BOOK, PREV_PAGE, NEXT_PAGE };
+  enum class EntryType { SECTION, FACET_SECTION, FACET, LOCAL_SECTION, LOCAL_BOOK, SEARCH, BOOK };
   // Which listing the BROWSING state currently shows; drives Back navigation.
   enum class NavLevel { Root, FacetList, Books };
 
@@ -74,10 +74,13 @@ class BookOrbitCatalogBrowserActivity final : public Activity {
   void launchWifiSelection();
   void onWifiSelectionComplete(bool connected);
   void showLoadingBeforeFetch();
-  void loadRoot();
+  bool loadRoot(bool allowNetwork = true);
   void loadLocalBooks(const std::string& kind);
-  void loadFacetEntries(const std::string& sectionId, const std::string& title, int page);
-  void loadBooks(const BookOrbitBookQuery& query, const std::string& title, int page, bool fromFacet);
+  bool loadFacetEntries(const std::string& sectionId, const std::string& title, int page, bool append = false,
+                        bool allowNetwork = true);
+  bool loadBooks(const BookOrbitBookQuery& query, const std::string& title, int page, bool fromFacet,
+                 bool append = false, bool allowNetwork = true);
+  bool appendNextPageForCurrentList(size_t previousCount);
   void launchSearch();
   void performSearch(const std::string& query);
   void downloadBook(int64_t bookId, const std::string& title);

--- a/src/activities/browser/BookOrbitCatalogListCache.cpp
+++ b/src/activities/browser/BookOrbitCatalogListCache.cpp
@@ -1,0 +1,223 @@
+#include "BookOrbitCatalogListCache.h"
+
+#include <ArduinoJson.h>
+#include <HalStorage.h>
+#include <Logging.h>
+
+#include <cstdio>
+#include <cstring>
+#include <functional>
+
+namespace {
+constexpr char BOOKORBIT_LIST_CACHE_DIR[] = "/.crosspoint/bookorbit_lists";
+constexpr char BOOKORBIT_LIST_CACHE_PREFIX[] = "bookorbit_list_";
+constexpr char BOOKORBIT_LIST_CACHE_SUFFIX[] = ".json";
+constexpr size_t BOOKORBIT_CACHE_PATH_CAP = 180;
+
+bool writeJsonStringFile(const std::string& path, const std::string& text) {
+  FsFile file;
+  if (!Storage.openFileForWrite("BookOrbit", path, file)) {
+    LOG_ERR("BookOrbit", "Failed to open cache for write: %s", path.c_str());
+    return false;
+  }
+  const size_t written = file.write(reinterpret_cast<const uint8_t*>(text.data()), text.size());
+  const bool ok = written == text.size() && file.close();
+  if (!ok) {
+    LOG_ERR("BookOrbit", "Failed to write full cache file: %s", path.c_str());
+    Storage.remove(path.c_str());
+  }
+  return ok;
+}
+
+bool readJsonStringFile(const std::string& path, std::string& out) {
+  out.clear();
+  FsFile file;
+  if (!Storage.openFileForRead("BookOrbit", path, file)) {
+    return false;
+  }
+  const size_t size = file.fileSize();
+  if (size == 0 || size > 24576) {
+    file.close();
+    return false;
+  }
+  out.resize(size);
+  const int n = file.read(out.data(), size);
+  file.close();
+  if (n <= 0 || static_cast<size_t>(n) != size) {
+    out.clear();
+    return false;
+  }
+  return true;
+}
+
+std::string cachePathForKey(const std::string& key) {
+  const size_t hash = std::hash<std::string>{}(key);
+  char path[BOOKORBIT_CACHE_PATH_CAP];
+  snprintf(path, sizeof(path), "%s/%s%08lx%s", BOOKORBIT_LIST_CACHE_DIR, BOOKORBIT_LIST_CACHE_PREFIX,
+           static_cast<unsigned long>(hash & 0xffffffffUL), BOOKORBIT_LIST_CACHE_SUFFIX);
+  return path;
+}
+
+void appendJsonEscaped(std::string& out, const std::string& value) {
+  out += '"';
+  for (char c : value) {
+    if (c == '"' || c == '\\') {
+      out += '\\';
+      out += c;
+    } else if (c == '\n') {
+      out += "\\n";
+    } else if (c == '\r') {
+      out += "\\r";
+    } else if (c == '\t') {
+      out += "\\t";
+    } else {
+      out += c;
+    }
+  }
+  out += '"';
+}
+
+std::string booksCacheKey(const BookOrbitBookQuery& query, const int page) {
+  return std::string("books|") + std::to_string(page) + "|" + query.sort + "|" + query.query + "|" + query.author +
+         "|" + query.seriesId + "|" + query.series;
+}
+
+std::string facetCacheKey(const std::string& sectionId, const int page) {
+  return std::string("facet|") + sectionId + "|" + std::to_string(page);
+}
+}  // namespace
+
+namespace BookOrbitCatalogListCache {
+
+void clear() {
+  Storage.mkdir("/.crosspoint");
+  Storage.mkdir(BOOKORBIT_LIST_CACHE_DIR);
+
+  FsFile dir = Storage.open(BOOKORBIT_LIST_CACHE_DIR);
+  if (!dir || !dir.isDirectory()) return;
+
+  char name[96];
+  FsFile file;
+  while ((file = dir.openNextFile())) {
+    const size_t nameLen = file.isDirectory() ? 0 : file.getName(name, sizeof(name));
+    file.close();
+    if (nameLen == 0) continue;
+    if (std::strncmp(name, BOOKORBIT_LIST_CACHE_PREFIX, std::strlen(BOOKORBIT_LIST_CACHE_PREFIX)) != 0) continue;
+    const std::string fullPath = std::string(BOOKORBIT_LIST_CACHE_DIR) + "/" + std::string(name, nameLen);
+    Storage.remove(fullPath.c_str());
+  }
+  dir.close();
+}
+
+bool loadRootSections(std::vector<BookOrbitCatalogSection>& outSections) {
+  std::string text;
+  if (!readJsonStringFile(cachePathForKey("root"), text)) return false;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, text) != DeserializationError::Ok || !doc["sections"].is<JsonArray>()) return false;
+
+  outSections.clear();
+  for (JsonObjectConst section : doc["sections"].as<JsonArrayConst>()) {
+    BookOrbitCatalogSection entry;
+    entry.id = std::string(section["id"] | "");
+    entry.title = std::string(section["title"] | "");
+    outSections.push_back(std::move(entry));
+  }
+  return !outSections.empty();
+}
+
+void saveRootSections(const std::vector<BookOrbitCatalogSection>& sections) {
+  std::string json;
+  json.reserve(64 + sections.size() * 48);
+  json += "{\"sections\":[";
+  for (size_t i = 0; i < sections.size(); i++) {
+    if (i > 0) json += ",";
+    json += "{\"id\":";
+    appendJsonEscaped(json, sections[i].id);
+    json += ",\"title\":";
+    appendJsonEscaped(json, sections[i].title);
+    json += "}";
+  }
+  json += "]}";
+  writeJsonStringFile(cachePathForKey("root"), json);
+}
+
+bool loadFacetPage(const std::string& sectionId, const int page, BookOrbitFacetPage& outPage) {
+  std::string text;
+  if (!readJsonStringFile(cachePathForKey(facetCacheKey(sectionId, page)), text)) return false;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, text) != DeserializationError::Ok || !doc["items"].is<JsonArray>()) return false;
+
+  outPage = BookOrbitFacetPage{};
+  outPage.page = doc["page"] | page;
+  outPage.hasNext = doc["hasNext"] | false;
+  for (JsonObjectConst item : doc["items"].as<JsonArrayConst>()) {
+    BookOrbitFacetEntry entry;
+    entry.id = std::string(item["id"] | "");
+    entry.title = std::string(item["title"] | "");
+    entry.seriesId = std::string(item["seriesId"] | "");
+    entry.count = item["count"] | 0;
+    outPage.entries.push_back(std::move(entry));
+  }
+  return true;
+}
+
+void saveFacetPage(const std::string& sectionId, const int page, const BookOrbitFacetPage& pageData) {
+  std::string json;
+  json.reserve(96 + pageData.entries.size() * 80);
+  json += "{\"page\":" + std::to_string(pageData.page) +
+          ",\"hasNext\":" + std::string(pageData.hasNext ? "true" : "false") + ",\"items\":[";
+  for (size_t i = 0; i < pageData.entries.size(); i++) {
+    if (i > 0) json += ",";
+    json += "{\"id\":";
+    appendJsonEscaped(json, pageData.entries[i].id);
+    json += ",\"title\":";
+    appendJsonEscaped(json, pageData.entries[i].title);
+    json += ",\"seriesId\":";
+    appendJsonEscaped(json, pageData.entries[i].seriesId);
+    json += ",\"count\":" + std::to_string(pageData.entries[i].count) + "}";
+  }
+  json += "]}";
+  writeJsonStringFile(cachePathForKey(facetCacheKey(sectionId, page)), json);
+}
+
+bool loadBooksPage(const BookOrbitBookQuery& query, const int page, BookOrbitBookPage& outPage) {
+  std::string text;
+  if (!readJsonStringFile(cachePathForKey(booksCacheKey(query, page)), text)) return false;
+
+  JsonDocument doc;
+  if (deserializeJson(doc, text) != DeserializationError::Ok || !doc["items"].is<JsonArray>()) return false;
+
+  outPage = BookOrbitBookPage{};
+  outPage.page = doc["page"] | page;
+  outPage.total = doc["total"] | 0;
+  outPage.pageSize = doc["size"] | BookOrbitCatalogClient::PAGE_SIZE;
+  for (JsonObjectConst item : doc["items"].as<JsonArrayConst>()) {
+    BookOrbitCatalogBook book;
+    book.id = item["id"] | 0;
+    book.title = std::string(item["title"] | "");
+    book.author = std::string(item["author"] | "");
+    outPage.books.push_back(std::move(book));
+  }
+  return true;
+}
+
+void saveBooksPage(const BookOrbitBookQuery& query, const int page, const BookOrbitBookPage& pageData) {
+  std::string json;
+  json.reserve(112 + pageData.books.size() * 80);
+  json += "{\"page\":" + std::to_string(pageData.page) + ",\"total\":" + std::to_string(pageData.total) +
+          ",\"size\":" + std::to_string(pageData.pageSize) + ",\"items\":[";
+  for (size_t i = 0; i < pageData.books.size(); i++) {
+    if (i > 0) json += ",";
+    json += "{\"id\":" + std::to_string(pageData.books[i].id) + ",\"title\":";
+    appendJsonEscaped(json, pageData.books[i].title);
+    json += ",\"author\":";
+    appendJsonEscaped(json, pageData.books[i].author);
+    json += "}";
+  }
+  json += "]}";
+  writeJsonStringFile(cachePathForKey(booksCacheKey(query, page)), json);
+}
+
+}  // namespace BookOrbitCatalogListCache

--- a/src/activities/browser/BookOrbitCatalogListCache.h
+++ b/src/activities/browser/BookOrbitCatalogListCache.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "network/BookOrbitCatalogClient.h"
+
+namespace BookOrbitCatalogListCache {
+
+void clear();
+
+bool loadRootSections(std::vector<BookOrbitCatalogSection>& outSections);
+void saveRootSections(const std::vector<BookOrbitCatalogSection>& sections);
+
+bool loadFacetPage(const std::string& sectionId, int page, BookOrbitFacetPage& outPage);
+void saveFacetPage(const std::string& sectionId, int page, const BookOrbitFacetPage& pageData);
+
+bool loadBooksPage(const BookOrbitBookQuery& query, int page, BookOrbitBookPage& outPage);
+void saveBooksPage(const BookOrbitBookQuery& query, int page, const BookOrbitBookPage& pageData);
+
+}  // namespace BookOrbitCatalogListCache

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -295,7 +295,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                          const std::function<std::string(int index)>& rowValue, bool highlightValue,
                          const std::function<bool(int index)>& rowDimmed,
                          const std::function<bool(int index)>& isHeader, const int rowHeightScale,
-                         const bool showSelection) const {
+                         const bool showSelection, const int totalItemCount) const {
   const int rowScale = std::max(1, rowHeightScale);
   int rowHeight =
       ((rowSubtitle != nullptr) ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight) *
@@ -303,7 +303,11 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   int pageItems = rowHeight > 0 ? std::max(1, rect.height / rowHeight) : 1;
   constexpr int sectionHeaderTopPadding = 15;
 
-  const int totalPages = (itemCount + pageItems - 1) / pageItems;
+  // The scroll indicator reflects the full listing when the caller knows it is
+  // longer than what is loaded (paged server catalogs): its size and position
+  // are then right on the first draw and stable as further pages append.
+  const int scrollItemCount = std::max(itemCount, totalItemCount);
+  const int totalPages = (scrollItemCount + pageItems - 1) / pageItems;
   if (totalPages > 1) {
     constexpr int indicatorWidth = 20;
     constexpr int arrowSize = 6;
@@ -378,25 +382,29 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                         EpdFontFamily::BOLD);
       continue;
     }
-    renderer.drawText(font, rect.x + BaseMetrics::values.contentSidePadding, itemY, item.c_str(), i != selectedIndex);
+    // Per row, not per list: a row whose subtitle is empty centers its title in
+    // the subtitle-height row instead of leaving the subtitle's blank line under it.
+    std::string subtitleText;
+    if (rowSubtitle != nullptr) subtitleText = rowSubtitle(i);
+    const int titleY = rowSubtitle != nullptr && subtitleText.empty()
+                           ? itemY + std::max(0, (rowHeight - renderer.getLineHeight(font)) / 2)
+                           : itemY;
+    renderer.drawText(font, rect.x + BaseMetrics::values.contentSidePadding, titleY, item.c_str(), i != selectedIndex);
 
     // Apply checkerboard dither to create gray text effect for dimmed items
     if (rowDimmed && rowDimmed(i) && i != selectedIndex) {
       const int titleWidth = renderer.getTextWidth(font, item.c_str());
       const int lineH = renderer.getLineHeight(font);
       const int tx = rect.x + BaseMetrics::values.contentSidePadding;
-      for (int py = itemY; py < itemY + lineH; py++)
+      for (int py = titleY; py < titleY + lineH; py++)
         for (int px = tx; px < tx + titleWidth; px++)
           if ((px + py) % 2 == 0) renderer.drawPixel(px, py, false);
     }
 
-    if (rowSubtitle != nullptr) {
-      std::string subtitleText = rowSubtitle(i);
-      if (!subtitleText.empty()) {
-        auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
-        renderer.drawText(SMALL_FONT_ID, rect.x + BaseMetrics::values.contentSidePadding, itemY + 22, subtitle.c_str(),
-                          i != selectedIndex);
-      }
+    if (!subtitleText.empty()) {
+      auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
+      renderer.drawText(SMALL_FONT_ID, rect.x + BaseMetrics::values.contentSidePadding, itemY + 22, subtitle.c_str(),
+                        i != selectedIndex);
     }
 
     if (!valueText.empty()) {

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -241,6 +241,10 @@ class BaseTheme {
   virtual int getMenuRowHeight(const GfxRenderer& renderer) const;
   virtual int getListRowStep(bool hasSubtitle, int rowHeightScale = 1) const;
   virtual int getListPageItems(int contentHeight, bool hasSubtitle, int rowHeightScale = 1) const;
+  // totalItemCount sizes the scroll indicator when the list is a loaded prefix of
+  // a longer server-side listing (itemCount rows exist, totalItemCount are known
+  // to exist). Rows are still drawn from the first itemCount entries only; -1
+  // keeps the indicator based on itemCount.
   virtual void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
                         const std::function<std::string(int index)>& rowTitle,
                         const std::function<std::string(int index)>& rowSubtitle = nullptr,
@@ -248,7 +252,7 @@ class BaseTheme {
                         const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
                         const std::function<bool(int index)>& rowDimmed = nullptr,
                         const std::function<bool(int index)>& isHeader = nullptr, int rowHeightScale = 1,
-                        bool showSelection = true) const;
+                        bool showSelection = true, int totalItemCount = -1) const;
   virtual void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle = nullptr,
                           bool readerContext = false) const;
   virtual void drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label,

--- a/src/components/themes/lyra/LyraCarouselTheme.cpp
+++ b/src/components/themes/lyra/LyraCarouselTheme.cpp
@@ -685,8 +685,8 @@ void LyraCarouselTheme::drawList(const GfxRenderer& renderer, Rect rect, int ite
                                  const std::function<std::string(int index)>& rowValue, bool highlightValue,
                                  const std::function<bool(int index)>& rowDimmed,
                                  const std::function<bool(int index)>& isHeader, const int rowHeightScale,
-                                 const bool showSelection) const {
+                                 const bool showSelection, const int totalItemCount) const {
   drawListWithMetrics(renderer, rect, itemCount, selectedIndex, rowTitle, rowSubtitle, rowIcon, rowValue,
                       highlightValue, rowDimmed, isHeader, LyraCarouselMetrics::values, true, rowHeightScale,
-                      showSelection);
+                      showSelection, totalItemCount);
 }

--- a/src/components/themes/lyra/LyraCarouselTheme.h
+++ b/src/components/themes/lyra/LyraCarouselTheme.h
@@ -66,6 +66,6 @@ class LyraCarouselTheme : public LyraTheme {
                 const std::function<UIIcon(int index)>& rowIcon = {},
                 const std::function<std::string(int index)>& rowValue = {}, bool highlightValue = false,
                 const std::function<bool(int index)>& rowDimmed = {},
-                const std::function<bool(int index)>& isHeader = {}, int rowHeightScale = 1,
-                bool showSelection = true) const override;
+                const std::function<bool(int index)>& isHeader = {}, int rowHeightScale = 1, bool showSelection = true,
+                int totalItemCount = -1) const override;
 };

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -198,9 +198,10 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                          const std::function<std::string(int index)>& rowValue, bool highlightValue,
                          const std::function<bool(int index)>& rowDimmed,
                          const std::function<bool(int index)>& isHeader, const int rowHeightScale,
-                         const bool showSelection) const {
+                         const bool showSelection, const int totalItemCount) const {
   drawListWithMetrics(renderer, rect, itemCount, selectedIndex, rowTitle, rowSubtitle, rowIcon, rowValue,
-                      highlightValue, rowDimmed, isHeader, LyraMetrics::values, false, rowHeightScale, showSelection);
+                      highlightValue, rowDimmed, isHeader, LyraMetrics::values, false, rowHeightScale, showSelection,
+                      totalItemCount);
 }
 
 void LyraTheme::drawListWithMetrics(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
@@ -210,8 +211,8 @@ void LyraTheme::drawListWithMetrics(const GfxRenderer& renderer, Rect rect, int 
                                     const std::function<std::string(int index)>& rowValue, bool highlightValue,
                                     const std::function<bool(int index)>& rowDimmed,
                                     const std::function<bool(int index)>& isHeader, const ThemeMetrics& metrics,
-                                    const bool invertSelectedRows, const int rowHeightScale,
-                                    const bool showSelection) const {
+                                    const bool invertSelectedRows, const int rowHeightScale, const bool showSelection,
+                                    const int totalItemCount) const {
   const int rowScale = std::max(1, rowHeightScale);
   int rowHeight = ((rowSubtitle != nullptr) ? metrics.listWithSubtitleRowHeight : metrics.listRowHeight) * rowScale;
   if (itemCount <= 0) return;
@@ -227,15 +228,19 @@ void LyraTheme::drawListWithMetrics(const GfxRenderer& renderer, Rect rect, int 
     if (i > 0 && isHeaderRow(i)) totalContentHeight += sectionHeaderTopPadding;
     totalContentHeight += visualRowHeight(i);
   }
-  const bool contentFits = totalContentHeight <= rect.height;
+  // The scroll indicator reflects the full listing when the caller knows it is
+  // longer than what is loaded its size and position are then right on the
+  // first draw and stable as further pages append.
+  const int scrollItemCount = std::max(itemCount, totalItemCount);
+  const bool contentFits = totalContentHeight <= rect.height && scrollItemCount <= itemCount;
   int pageItems = contentFits ? itemCount : (rowHeight > 0 ? std::max(1, rect.height / rowHeight) : 1);
 
-  const int totalPages = (itemCount + pageItems - 1) / pageItems;
+  const int totalPages = (scrollItemCount + pageItems - 1) / pageItems;
   if (!contentFits && totalPages > 1) {
     const int scrollAreaHeight = rect.height;
 
     // Draw scroll bar
-    const int scrollBarHeight = (scrollAreaHeight * pageItems) / itemCount;
+    const int scrollBarHeight = std::max(1, (scrollAreaHeight * pageItems) / scrollItemCount);
     const int currentPage = selectedIndex / pageItems;
     const int scrollBarY = rect.y + ((scrollAreaHeight - scrollBarHeight) * currentPage) / (totalPages - 1);
     const int scrollBarX = rect.x + rect.width - metrics.scrollBarRightOffset;
@@ -309,7 +314,11 @@ void LyraTheme::drawListWithMetrics(const GfxRenderer& renderer, Rect rect, int 
 
     auto itemName = rowTitle(i);
     auto item = renderer.truncatedText(UI_10_FONT_ID, itemName.c_str(), rowTextWidth);
-    const int titleY = rowSubtitle != nullptr ? itemY + 7 : centeredRowY(itemY, currentRowHeight, titleLineHeight);
+    // Per row, not per list: a row whose subtitle is empty centers its title in
+    // the tall row instead of leaving the subtitle's blank line under it.
+    std::string subtitleText;
+    if (rowSubtitle != nullptr) subtitleText = rowSubtitle(i);
+    const int titleY = !subtitleText.empty() ? itemY + 7 : centeredRowY(itemY, currentRowHeight, titleLineHeight);
     renderer.drawText(UI_10_FONT_ID, textX, titleY, item.c_str(), foreground);
 
     // Apply checkerboard dither to create gray text effect for dimmed items
@@ -326,7 +335,7 @@ void LyraTheme::drawListWithMetrics(const GfxRenderer& renderer, Rect rect, int 
       if (iconBitmap != nullptr) {
         const int iconX = rect.x + metrics.contentSidePadding + hPaddingInSelection;
         const int iconY =
-            rowSubtitle != nullptr ? itemY + 16 : centeredRowY(itemY, currentRowHeight, static_cast<int>(iconSize));
+            !subtitleText.empty() ? itemY + 16 : centeredRowY(itemY, currentRowHeight, static_cast<int>(iconSize));
         if (invertSelectedRows && selectedRow) {
           drawLucideIcon(renderer, *iconBitmap, iconX, iconY, false);
         } else {
@@ -335,9 +344,7 @@ void LyraTheme::drawListWithMetrics(const GfxRenderer& renderer, Rect rect, int 
       }
     }
 
-    if (rowSubtitle != nullptr) {
-      // Draw subtitle
-      std::string subtitleText = rowSubtitle(i);
+    if (!subtitleText.empty()) {
       auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
       renderer.drawText(SMALL_FONT_ID, textX, itemY + 30, subtitle.c_str(), foreground);
     }

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -107,7 +107,7 @@ class LyraTheme : public BaseTheme {
                 const std::function<UIIcon(int index)>& rowIcon, const std::function<std::string(int index)>& rowValue,
                 bool highlightValue, const std::function<bool(int index)>& rowDimmed = nullptr,
                 const std::function<bool(int index)>& isHeader = nullptr, int rowHeightScale = 1,
-                bool showSelection = true) const override;
+                bool showSelection = true, int totalItemCount = -1) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3, const char* btn4,
                        bool allowInvertedText = false) const override;
   void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const override;
@@ -130,7 +130,8 @@ class LyraTheme : public BaseTheme {
                            const std::function<std::string(int index)>& rowValue, bool highlightValue,
                            const std::function<bool(int index)>& rowDimmed,
                            const std::function<bool(int index)>& isHeader, const ThemeMetrics& metrics,
-                           bool invertSelectedRows, int rowHeightScale = 1, bool showSelection = true) const;
+                           bool invertSelectedRows, int rowHeightScale = 1, bool showSelection = true,
+                           int totalItemCount = -1) const;
 
   // Returns nullptr when the icon or requested bitmap size is not available.
   static const freeink::Icon* iconForName(UIIcon icon, uint32_t size);

--- a/src/components/themes/minimal/MinimalTheme.cpp
+++ b/src/components/themes/minimal/MinimalTheme.cpp
@@ -481,11 +481,11 @@ void MinimalTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCoun
                             const std::function<std::string(int index)>& rowValue, bool highlightValue,
                             const std::function<bool(int index)>& rowDimmed,
                             const std::function<bool(int index)>& isHeader, const int rowHeightScale,
-                            const bool showSelection) const {
+                            const bool showSelection, const int totalItemCount) const {
   const bool compactFileRows = rowSubtitle != nullptr && rowIcon != nullptr && rowValue != nullptr;
   if (!compactFileRows) {
     LyraTheme::drawList(renderer, rect, itemCount, selectedIndex, rowTitle, rowSubtitle, rowIcon, rowValue,
-                        highlightValue, rowDimmed, isHeader, rowHeightScale, showSelection);
+                        highlightValue, rowDimmed, isHeader, rowHeightScale, showSelection, totalItemCount);
     return;
   }
 

--- a/src/components/themes/minimal/MinimalTheme.h
+++ b/src/components/themes/minimal/MinimalTheme.h
@@ -55,7 +55,7 @@ class MinimalTheme : public LyraTheme {
                 const std::function<UIIcon(int index)>& rowIcon, const std::function<std::string(int index)>& rowValue,
                 bool highlightValue, const std::function<bool(int index)>& rowDimmed = nullptr,
                 const std::function<bool(int index)>& isHeader = nullptr, int rowHeightScale = 1,
-                bool showSelection = true) const override;
+                bool showSelection = true, int totalItemCount = -1) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3, const char* btn4,
                        bool allowInvertedText = false) const override;
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -282,7 +282,7 @@ void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int item
                                 const std::function<std::string(int index)>& rowValue, bool highlightValue,
                                 const std::function<bool(int index)>& rowDimmed,
                                 const std::function<bool(int index)>& isHeader, const int rowHeightScale,
-                                const bool showSelection) const {
+                                const bool showSelection, const int totalItemCount) const {
   (void)rowIcon;
   (void)highlightValue;
   (void)rowDimmed;
@@ -398,7 +398,7 @@ void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int item
     }
   }
 
-  drawScrollBar(renderer, rect, itemCount, pageStartIndex, pageItems);
+  drawScrollBar(renderer, rect, std::max(itemCount, totalItemCount), pageStartIndex, pageItems);
 }
 
 void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,

--- a/src/components/themes/roundedraff/RoundedRaffTheme.h
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.h
@@ -114,7 +114,7 @@ class RoundedRaffTheme : public BaseTheme {
                 const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
                 const std::function<bool(int index)>& rowDimmed = nullptr,
                 const std::function<bool(int index)>& isHeader = nullptr, int rowHeightScale = 1,
-                bool showSelection = true) const override;
+                bool showSelection = true, int totalItemCount = -1) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3, const char* btn4,
                        bool allowInvertedText = false) const override;
   bool homeMenuShowsContinueReading() const { return true; }


### PR DESCRIPTION
## Summary

Superseeds https://github.com/agosez/CrossInk-Bookorbit/pull/22.

Thanks to the contribution of @CaptainFrito:

- Use theme UI components for BookOrbit navigation
- Add basic caching to BookOrbit navigation to avoid having to reload the same lists. Cache is cleared each time we enter the Activity
- Keep BookOrbit server ordering response to take advantage of alphabetically or rencency ordered entries when relevant
- Add author subtitle
- Add seemless scrolling

